### PR TITLE
Add admin registrations

### DIFF
--- a/council_finance/admin.py
+++ b/council_finance/admin.py
@@ -1,0 +1,22 @@
+# Django admin registration for finance models
+# This file ensures backend users can manage imported data easily via /admin/
+
+from django.contrib import admin
+
+from .models.council import (
+    Council,
+    FinancialYear,
+    FigureSubmission,
+    DebtAdjustment,
+    WhistleblowerReport,
+    ModerationLog,
+)
+
+# Register core models in the Django admin.
+# Using admin.site.register is sufficient for simple use cases.
+admin.site.register(Council)
+admin.site.register(FinancialYear)
+admin.site.register(FigureSubmission)
+admin.site.register(DebtAdjustment)
+admin.site.register(WhistleblowerReport)
+admin.site.register(ModerationLog)


### PR DESCRIPTION
## Summary
- register all council finance models in the Django admin
- ensure the admin route is enabled for backend users

## Testing
- `pip install -r requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6863dfdf59548331aa0ddc73910faf51