### PR TITLE
Implement council listing views

### DIFF
--- a/council_finance/templates/council_finance/council_detail.html
+++ b/council_finance/templates/council_finance/council_detail.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{{ council.name }}</title>
+</head>
+<body>
+    <h1>{{ council.name }}</h1>
+    <p>Slug: {{ council.slug }}</p>
+    {% if council.website %}
+    <p>Website: <a href="{{ council.website }}">{{ council.website }}</a></p>
+    {% endif %}
+    {% if council.council_type %}
+    <p>Type: {{ council.council_type }}</p>
+    {% endif %}
+    <p><a href="{% url 'council_list' %}">Back to all councils</a></p>
+</body>
+</html>

--- a/council_finance/templates/council_finance/council_list.html
+++ b/council_finance/templates/council_finance/council_list.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Councils</title>
+</head>
+<body>
+    <h1>Councils</h1>
+    <form method="get">
+        <input type="text" name="q" value="{{ query }}" placeholder="Search by name or slug">
+        <button type="submit">Search</button>
+    </form>
+    <ul>
+    {% for council in councils %}
+        <li><a href="{% url 'council_detail' council.slug %}">{{ council.name }}</a></li>
+    {% empty %}
+        <li>No councils found.</li>
+    {% endfor %}
+    </ul>
+</body>
+</html>

--- a/council_finance/urls.py
+++ b/council_finance/urls.py
@@ -1,7 +1,10 @@
 from django.contrib import admin
 from django.urls import path, include
+from . import views
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('plugins/', include('core.urls')),
+    path('councils/', views.council_list, name='council_list'),
+    path('councils/<slug:slug>/', views.council_detail, name='council_detail'),
 ]

--- a/council_finance/views.py
+++ b/council_finance/views.py
@@ -1,0 +1,37 @@
+from django.shortcuts import render, get_object_or_404
+from django.db.models import Q
+
+from .models import Council
+
+
+def council_list(request):
+    """Display a list of councils with optional search by name or slug."""
+    # Grab search term from query parameters if provided
+    query = request.GET.get('q', '')
+
+    # Base queryset of all councils
+    councils = Council.objects.all()
+
+    # Apply a simple case-insensitive name or slug filter when a query is present
+    if query:
+        councils = councils.filter(
+            Q(name__icontains=query) | Q(slug__icontains=query)
+        )
+    context = {
+        "councils": councils,
+        "query": query,
+    }
+    return render(request, "council_finance/council_list.html", context)
+
+
+def council_detail(request, slug):
+    """Show details for a single council."""
+    # Fetch the council or return a 404 if the slug is unknown
+    council = get_object_or_404(Council, slug=slug)
+
+    # Pass the object straight through to the template for display
+    return render(
+        request,
+        "council_finance/council_detail.html",
+        {"council": council},
+    )


### PR DESCRIPTION
## Summary
- add council list and detail views
- create HTML templates for listing and detail display
- document view logic with inline comments
- route new endpoints in project urls

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6863dfe42fcc833199b6c3dccfea7725