### PR TITLE
Add authentication views

### DIFF
--- a/council_finance/settings.py
+++ b/council_finance/settings.py
@@ -39,7 +39,9 @@ ROOT_URLCONF = 'council_finance.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        # Look for templates in the project-level "templates" directory so
+        # apps and built-in views can share a consistent style.
+        'DIRS': [BASE_DIR / 'templates'],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [

--- a/council_finance/urls.py
+++ b/council_finance/urls.py
@@ -1,7 +1,17 @@
 from django.contrib import admin
 from django.urls import path, include
+# Import Django's built-in authentication views so we can easily
+# provide login and logout functionality.
+from django.contrib.auth.views import LoginView, LogoutView
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('plugins/', include('core.urls')),
+    # Authentication endpoints for administrators and visitors.
+    path('accounts/login/',
+         LoginView.as_view(template_name='registration/login.html'),
+         name='login'),
+    path('accounts/logout/',
+         LogoutView.as_view(template_name='registration/logged_out.html'),
+         name='logout'),
 ]

--- a/templates/registration/logged_out.html
+++ b/templates/registration/logged_out.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Logged out - Council Finance Counters</title>
+    <style>
+        body { font-family: sans-serif; max-width: 600px; margin: auto; padding: 2em; }
+    </style>
+</head>
+<body>
+    <h1>Signed out</h1>
+    <p>You have been logged out.</p>
+    <p><a href="{% url 'login' %}">Log in again</a></p>
+</body>
+</html>

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Log in - Council Finance Counters</title>
+    <style>
+        /* Simple styles to match the minimal project aesthetic */
+        body { font-family: sans-serif; max-width: 600px; margin: auto; padding: 2em; }
+        h1 { font-size: 1.5em; }
+        form { display: flex; flex-direction: column; gap: 1em; }
+        label { font-weight: bold; }
+        input[type="submit"] { width: fit-content; padding: 0.5em 1em; }
+    </style>
+</head>
+<body>
+    <h1>Please sign in</h1>
+    {% if form.errors %}
+        <p style="color:red;">Invalid username or password.</p>
+    {% endif %}
+    <form method="post">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <input type="submit" value="Log in">
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- set template directory so built-in pages can share our style
- expose `LoginView` and `LogoutView` for administrators and visitors
- style login/logout templates under `templates/registration`

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6863dfe6fffc83318b18acfea9a781a1