### PR TITLE
Add basic landing page

### DIFF
--- a/council_finance/templates/council_finance/home.html
+++ b/council_finance/templates/council_finance/home.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Council Finance Counters</title>
+</head>
+<body>
+    <h1>Welcome to Council Finance Counters</h1>
+    <p>Total council debt: {{ total_debt|floatformat:0 }}</p>
+
+    <form method="get" action="{% url 'home' %}">
+        <input type="text" name="q" value="{{ query }}" placeholder="Search councils">
+        <button type="submit">Search</button>
+    </form>
+    <ul>
+    {% for council in councils %}
+        <li><a href="{% url 'council_detail' council.slug %}">{{ council.name }}</a></li>
+    {% empty %}
+        {% if query %}
+        <li>No councils found.</li>
+        {% endif %}
+    {% endfor %}
+    </ul>
+</body>
+</html>

--- a/council_finance/tests/test_home.py
+++ b/council_finance/tests/test_home.py
@@ -1,0 +1,20 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.core.management import call_command
+from council_finance.models import Council
+
+
+class HomeViewTest(TestCase):
+    def setUp(self):
+        # Load sample councils so the home view has data
+        call_command('runagent', 'ImporterAgent', '--source', 'councils-migration.json')
+
+    def test_home_page_renders(self):
+        response = self.client.get(reverse('home'))
+        self.assertEqual(response.status_code, 200)
+        # Ensure the template context includes the debt total
+        self.assertIn('total_debt', response.context)
+
+    def test_search_returns_results(self):
+        response = self.client.get(reverse('home'), {'q': 'Worthing'})
+        self.assertContains(response, 'Worthing Borough Council')

--- a/council_finance/urls.py
+++ b/council_finance/urls.py
@@ -6,6 +6,7 @@ from django.contrib.auth.views import LoginView, LogoutView
 from . import views
 
 urlpatterns = [
+    path('', views.home, name='home'),
     path('admin/', admin.site.urls),
     path('plugins/', include('core.urls')),
     # Authentication endpoints for administrators and visitors.


### PR DESCRIPTION
## Summary
- create a `home` view with council search and site-wide debt counter
- map the new view to `/`
- show the debt total and search box in a new template
- add tests for the landing page

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_686415e8e7f883319864db15c83042ab