### PR TITLE
Fix missing profile handling

### DIFF
--- a/council_finance/views.py
+++ b/council_finance/views.py
@@ -7,6 +7,7 @@ from django.contrib.auth.decorators import login_required
 from .forms import SignUpForm
 from django.contrib.auth import login
 from .models import Council, UserProfile
+from django.utils.crypto import get_random_string
 import hashlib
 from django.shortcuts import render, get_object_or_404
 from django.db.models import Q, Sum, DecimalField
@@ -139,7 +140,6 @@ def corrections(request):
         # Later we might store the message in the database
         submitted = True
     return render(request, "council_finance/corrections.html", {"submitted": submitted})
- =======
 
 @login_required
 def profile_view(request):
@@ -193,7 +193,11 @@ def update_postcode(request):
     if not postcode:
         return JsonResponse({"error": "Postcode required"}, status=400)
 
-    profile = request.user.profile
+    # Ensure the user has a profile; create one if missing.
+    profile, _ = UserProfile.objects.get_or_create(
+        user=request.user,
+        defaults={"confirmation_token": get_random_string(32)},
+    )
     profile.postcode = postcode
     profile.save()
     return JsonResponse({"postcode": profile.postcode})
@@ -203,7 +207,12 @@ def update_postcode(request):
 def resend_confirmation(request):
     """Send another confirmation email to the logged-in user."""
 
-    send_confirmation_email(request.user.profile, request)
+    # Gracefully handle users who were created before profiles existed.
+    profile, _ = UserProfile.objects.get_or_create(
+        user=request.user,
+        defaults={"confirmation_token": get_random_string(32)},
+    )
+    send_confirmation_email(profile, request)
     messages.info(request, "Confirmation email sent.")
     return redirect("profile")
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -20,7 +20,8 @@
                 <a href="{% url 'following' %}" class="hover:underline">Following</a>
                 <a href="{% url 'submit' %}" class="hover:underline">Submit</a>
                 {% if user.is_authenticated %}
-                <a href="{% url 'my_profile' %}" class="hover:underline">My Profile</a>
+                {# Use the real account profile page rather than the placeholder #}
+                <a href="{% url 'profile' %}" class="hover:underline">My Profile</a>
                 {% else %}
                 <a href="{% url 'login' %}" class="hover:underline">Login/Register</a>
                 {% endif %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -22,6 +22,10 @@
                 {% if user.is_authenticated %}
                 {# Use the real account profile page rather than the placeholder #}
                 <a href="{% url 'profile' %}" class="hover:underline">My Profile</a>
+                {% if user.is_staff or user.is_superuser %}
+                {# Provide quick access to the Django admin for staff users #}
+                <a href="{% url 'admin:index' %}" class="hover:underline">Admin</a>
+                {% endif %}
                 {% else %}
                 <a href="{% url 'login' %}" class="hover:underline">Login/Register</a>
                 {% endif %}


### PR DESCRIPTION
## Summary
- safely create profiles in `resend_confirmation` and `update_postcode`
- clean up stray merge marker

## Testing
- `python manage.py test -v 0`

------
https://chatgpt.com/codex/tasks/task_e_686439c2c4388331ae6ca1ffe6d52c13