### PR TITLE
Add year picker on council page

### DIFF
--- a/council_finance/templates/council_finance/council_detail.html
+++ b/council_finance/templates/council_finance/council_detail.html
@@ -9,41 +9,76 @@
 {% if council.council_type %}
 <p>Type: {{ council.council_type.name }}</p>
 {% endif %}
+<div class="mt-2">
+  <label for="year-select" class="sr-only">Financial year</label>
+  <select id="year-select" class="border rounded px-2 py-1">
+    {% for y in years %}
+      <option value="{{ y.label }}" {% if y.label == selected_year.label %}selected{% endif %}>{{ y.label }}</option>
+    {% endfor %}
+  </select>
+</div>
 {% if counters %}
 <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 my-6">
     {% for item in counters %}
-    <div class="bg-green-50 p-4 rounded shadow text-center">
+    <div class="bg-green-50 p-4 rounded shadow text-center" data-counter="{{ item.counter.slug }}">
         <p class="text-sm text-gray-600">{{ item.counter.name }}</p>
-        {% if item.error %}
-        <p class="text-red-700 text-sm">{{ item.error }}</p>
-        {% else %}
-        <p class="text-2xl font-bold" data-duration="{{ item.counter.duration }}" data-value="{{ item.value }}" data-formatted="{{ item.formatted }}">0</p>
-        {% endif %}
+        <p class="text-red-700 text-sm counter-error" {% if not item.error %}style="display:none"{% endif %}>{{ item.error }}</p>
+        <p class="text-2xl font-bold counter-value" data-duration="{{ item.counter.duration }}" data-value="{{ item.value }}" data-formatted="{{ item.formatted }}" {% if item.error %}style="display:none"{% endif %}>0</p>
         <p class="text-xs mt-1">{{ item.counter.explanation }}</p>
     </div>
     {% endfor %}
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/countup.js/2.6.2/countUp.umd.js"></script>
 <script>
-// Animate all counter elements using CountUp for smoother number transitions.
-// Only animate counters that have a numeric value.
-document.querySelectorAll('[data-duration]').forEach(el => {
-    if (!el.dataset.value) {
-        return;
-    }
+function animateCounters() {
+  document.querySelectorAll('.counter-value').forEach(el => {
+    if (!el.dataset.value) return;
     const end = parseFloat(el.dataset.value || '0');
-    const duration = parseInt(el.dataset.duration || '0') / 1000; // ms -> seconds
+    const dur = parseInt(el.dataset.duration || '0') / 1000;
     const display = el.dataset.formatted || end.toLocaleString();
-    const counter = new window.CountUp(el, end, {duration});
-    if (!counter.error) {
-        counter.start(() => {
-            // Ensure the final formatted string matches server-side formatting.
-            el.textContent = display;
-        });
+    const cu = new window.CountUp(el, end, {duration: dur});
+    if (!cu.error) {
+      cu.start(() => { el.textContent = display; });
     } else {
-        el.textContent = display;
+      el.textContent = display;
     }
+  });
+}
+
+async function loadCounters(year) {
+  const url = `{% url 'council_counters' council.slug %}?year=${encodeURIComponent(year)}`;
+  try {
+    const resp = await fetch(url, {headers: {'X-Requested-With': 'XMLHttpRequest'}});
+    const data = await resp.json();
+    Object.entries(data.counters).forEach(([slug, info]) => {
+      const container = document.querySelector(`[data-counter="${slug}"]`);
+      if (!container) return;
+      const valEl = container.querySelector('.counter-value');
+      const errEl = container.querySelector('.counter-error');
+      if (info.error) {
+        if (errEl) { errEl.textContent = info.error; errEl.style.display = ''; }
+        if (valEl) { valEl.style.display = 'none'; }
+      } else {
+        if (errEl) { errEl.textContent = ''; errEl.style.display = 'none'; }
+        if (valEl) {
+          valEl.dataset.value = info.value;
+          valEl.dataset.formatted = info.formatted;
+          valEl.dataset.duration = info.duration;
+          valEl.style.display = '';
+        }
+      }
+    });
+    animateCounters();
+  } catch (e) {
+    console.error('Failed to load counters', e);
+  }
+}
+
+document.getElementById('year-select').addEventListener('change', e => {
+  loadCounters(e.target.value);
 });
+
+animateCounters();
 </script>
 {% endif %}
 {% if figures %}

--- a/council_finance/tests/test_council_counters.py
+++ b/council_finance/tests/test_council_counters.py
@@ -1,0 +1,40 @@
+from django.test import TestCase
+from django.urls import reverse
+
+from council_finance.models import (
+    Council,
+    FinancialYear,
+    DataField,
+    FigureSubmission,
+    CounterDefinition,
+    CouncilCounter,
+)
+
+
+class CouncilCountersTest(TestCase):
+    def setUp(self):
+        self.council = Council.objects.create(name="Test", slug="test")
+        self.year = FinancialYear.objects.create(label="2024")
+        self.field = DataField.objects.create(slug="total_debt", name="Total Debt")
+        FigureSubmission.objects.create(
+            council=self.council,
+            year=self.year,
+            field=self.field,
+            value="100",
+        )
+        self.counter = CounterDefinition.objects.create(
+            name="Debt",
+            slug="debt",
+            formula="total_debt",
+            precision=0,
+            show_currency=False,
+        )
+        CouncilCounter.objects.create(council=self.council, counter=self.counter)
+
+    def test_endpoint_returns_counter_value(self):
+        url = reverse("council_counters", args=["test"])
+        resp = self.client.get(url, {"year": "2024"})
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()["counters"]["debt"]
+        self.assertEqual(data["value"], 100.0)
+        self.assertEqual(data["formatted"], "100")

--- a/council_finance/urls.py
+++ b/council_finance/urls.py
@@ -42,6 +42,11 @@ urlpatterns = [
     # Show information about the logged in user.
     path("accounts/profile/", views.profile_view, name="profile"),
     path("councils/", views.council_list, name="council_list"),
+    path(
+        "councils/<slug:slug>/counters/",
+        views.council_counters,
+        name="council_counters",
+    ),
     path("councils/<slug:slug>/", views.council_detail, name="council_detail"),
     # Common menu pages
     path("leaderboards/", views.leaderboards, name="leaderboards"),


### PR DESCRIPTION
## Summary
- add `council_counters` API endpoint and URL
- include financial year dropdown on council detail page
- fetch counters via AJAX when year changes
- test JSON counter endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866b2d48ff08331acd5984e2796b1a2