### PR TITLE
Add moderation actions for contributions

### DIFF
--- a/council_finance/migrations/0021_contribution_logs.py
+++ b/council_finance/migrations/0021_contribution_logs.py
@@ -1,0 +1,88 @@
+from django.db import migrations, models
+import django.db.models.deletion
+from django.conf import settings
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("council_finance", "0020_user_font_field"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="contribution",
+            name="edited",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name="userprofile",
+            name="points",
+            field=models.IntegerField(default=0),
+        ),
+        migrations.AddField(
+            model_name="userprofile",
+            name="rejection_count",
+            field=models.IntegerField(default=0),
+        ),
+        migrations.CreateModel(
+            name="RejectionLog",
+            fields=[
+                ("id", models.BigAutoField(primary_key=True, serialize=False)),
+                (
+                    "contribution",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        to="council_finance.contribution",
+                    ),
+                ),
+                (
+                    "council",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to="council_finance.council",
+                    ),
+                ),
+                (
+                    "field",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to="council_finance.datafield",
+                    ),
+                ),
+                (
+                    "year",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        to="council_finance.financialyear",
+                    ),
+                ),
+                ("value", models.CharField(max_length=255)),
+                (
+                    "reason",
+                    models.CharField(
+                        choices=[
+                            ("data_incorrect", "The data wasn't correct"),
+                            ("no_sources", "We can't find reliable sources"),
+                            ("other", "Other"),
+                        ],
+                        max_length=50,
+                    ),
+                ),
+                (
+                    "reviewed_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                ("created", models.DateTimeField(auto_now_add=True)),
+            ],
+            options={"ordering": ["-created"]},
+        ),
+    ]

--- a/council_finance/models/__init__.py
+++ b/council_finance/models/__init__.py
@@ -12,6 +12,7 @@ from .user_profile import UserProfile
 from .trust_tier import TrustTier
 from .contribution import Contribution
 from .data_change_log import DataChangeLog
+from .rejection_log import RejectionLog
 from .user_follow import UserFollow
 from .pending_profile_change import PendingProfileChange
 from .notification import Notification
@@ -35,6 +36,7 @@ __all__ = [
     'TrustTier',
     'Contribution',
     'DataChangeLog',
+    'RejectionLog',
     'CouncilList',
     'CounterDefinition',
     'CouncilCounter',

--- a/council_finance/models/contribution.py
+++ b/council_finance/models/contribution.py
@@ -24,6 +24,7 @@ class Contribution(models.Model):
     year = models.ForeignKey(FinancialYear, null=True, blank=True, on_delete=models.SET_NULL)
     value = models.CharField(max_length=255)
     status = models.CharField(max_length=20, choices=STATUS_CHOICES, default="pending")
+    edited = models.BooleanField(default=False)
     created = models.DateTimeField(auto_now_add=True)
 
     class Meta:

--- a/council_finance/models/rejection_log.py
+++ b/council_finance/models/rejection_log.py
@@ -1,0 +1,34 @@
+from django.conf import settings
+from django.db import models
+
+from .council import Council, FinancialYear
+from .field import DataField
+from .contribution import Contribution
+
+class RejectionLog(models.Model):
+    """Store details whenever a contribution is rejected."""
+
+    REASONS = [
+        ("data_incorrect", "The data wasn't correct"),
+        ("no_sources", "We can't find reliable sources"),
+        ("other", "Other"),
+    ]
+
+    contribution = models.ForeignKey(
+        Contribution, on_delete=models.SET_NULL, null=True, blank=True
+    )
+    council = models.ForeignKey(Council, on_delete=models.CASCADE)
+    field = models.ForeignKey(DataField, on_delete=models.CASCADE)
+    year = models.ForeignKey(FinancialYear, null=True, blank=True, on_delete=models.SET_NULL)
+    value = models.CharField(max_length=255)
+    reason = models.CharField(max_length=50, choices=REASONS)
+    reviewed_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, null=True, blank=True
+    )
+    created = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ["-created"]
+
+    def __str__(self) -> str:
+        return f"Rejected contribution {self.contribution_id} for {self.council}"

--- a/council_finance/models/user_profile.py
+++ b/council_finance/models/user_profile.py
@@ -60,6 +60,9 @@ class UserProfile(models.Model):
     # provide a clean, modern feel. Users can override this from their
     # profile page.
     preferred_font = models.CharField(max_length=100, default="Cairo", blank=True)
+    # Gamification fields tracking contribution performance.
+    points = models.IntegerField(default=0)
+    rejection_count = models.IntegerField(default=0)
 
     def __str__(self) -> str:
         return f"Profile for {self.user.username}"

--- a/council_finance/templates/council_finance/contribute.html
+++ b/council_finance/templates/council_finance/contribute.html
@@ -34,9 +34,12 @@
                     <td class="px-2 py-1">{{ c.created|date:"Y-m-d H:i" }}</td>
                     {% if user.is_authenticated and user.profile.tier.level >= 3 %}
                     <td class="px-2 py-1 space-x-2">
-                        <a href="{% url 'review_contribution' c.id 'approve' %}" class="text-green-600"><i class="fas fa-check"></i></a>
-                        <a href="{% url 'review_contribution' c.id 'edit' %}" class="text-blue-600"><i class="fas fa-edit"></i></a>
-                        <a href="{% url 'review_contribution' c.id 'reject' %}" class="text-red-600"><i class="fas fa-times"></i></a>
+                        <form method="post" action="{% url 'review_contribution' c.id 'approve' %}" class="inline">
+                            {% csrf_token %}
+                            <button class="text-green-600" aria-label="Approve"><i class="fas fa-check"></i></button>
+                        </form>
+                        <button class="edit-btn text-blue-600" data-url="{% url 'review_contribution' c.id 'edit' %}" data-value="{{ c.value }}" aria-label="Edit"><i class="fas fa-edit"></i></button>
+                        <button class="reject-btn text-red-600" data-url="{% url 'review_contribution' c.id 'reject' %}" aria-label="Reject"><i class="fas fa-times"></i></button>
                     </td>
                     {% endif %}
                 </tr>
@@ -98,4 +101,65 @@
         <p>Placeholder for the best rated submissions.</p>
     </section>
 </div>
+
+<!-- Modal used for editing a contribution -->
+<div id="edit-modal" class="hidden fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+  <form method="post" id="edit-form" class="bg-white p-4 rounded shadow">
+    {% csrf_token %}
+    <label class="block mb-2">New value
+      <input type="text" name="value" id="edit-value" class="border p-2 w-full" />
+    </label>
+    <div class="text-right space-x-2">
+      <button type="submit" class="bg-blue-600 text-white px-4 py-1 rounded">Save</button>
+      <button type="button" id="edit-cancel" class="px-4 py-1 border rounded">Cancel</button>
+    </div>
+  </form>
+</div>
+
+<!-- Modal used when rejecting a contribution -->
+<div id="reject-modal" class="hidden fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+  <form method="post" id="reject-form" class="bg-white p-4 rounded shadow">
+    {% csrf_token %}
+    <label class="block mb-2">Reason
+      <select name="reason" id="reject-reason" class="border p-2 w-full">
+        <option value="data_incorrect">The data wasn't correct</option>
+        <option value="no_sources">We can't find reliable sources</option>
+        <option value="other">Other (specify)</option>
+      </select>
+    </label>
+    <input type="text" name="details" id="reject-details" class="border p-2 w-full mb-2 hidden" placeholder="Details" />
+    <div class="text-right space-x-2">
+      <button type="submit" class="bg-red-600 text-white px-4 py-1 rounded">Reject</button>
+      <button type="button" id="reject-cancel" class="px-4 py-1 border rounded">Cancel</button>
+    </div>
+  </form>
+</div>
+
+<script>
+document.querySelectorAll('.edit-btn').forEach(btn => {
+  btn.addEventListener('click', e => {
+    e.preventDefault();
+    document.getElementById('edit-form').action = btn.dataset.url;
+    document.getElementById('edit-value').value = btn.dataset.value;
+    document.getElementById('edit-modal').classList.remove('hidden');
+  });
+});
+document.getElementById('edit-cancel').addEventListener('click', () => {
+  document.getElementById('edit-modal').classList.add('hidden');
+});
+
+document.querySelectorAll('.reject-btn').forEach(btn => {
+  btn.addEventListener('click', e => {
+    e.preventDefault();
+    document.getElementById('reject-form').action = btn.dataset.url;
+    document.getElementById('reject-modal').classList.remove('hidden');
+  });
+});
+document.getElementById('reject-cancel').addEventListener('click', () => {
+  document.getElementById('reject-modal').classList.add('hidden');
+});
+document.getElementById('reject-reason').addEventListener('change', function() {
+  document.getElementById('reject-details').classList.toggle('hidden', this.value !== 'other');
+});
+</script>
 {% endblock %}

--- a/council_finance/tests/test_contribution_review.py
+++ b/council_finance/tests/test_contribution_review.py
@@ -1,0 +1,69 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+
+from council_finance.models import (
+    TrustTier,
+    Council,
+    DataField,
+    Contribution,
+    DataChangeLog,
+    Notification,
+    RejectionLog,
+)
+
+class ContributionReviewTests(TestCase):
+    def setUp(self):
+        self.tier3 = TrustTier.objects.get(level=3)
+        self.mod = get_user_model().objects.create_user(
+            username="mod", email="mod@example.com", password="pw"
+        )
+        self.mod.profile.tier = self.tier3
+        self.mod.profile.save()
+        self.user = get_user_model().objects.create_user(
+            username="contrib", email="c@example.com", password="pw"
+        )
+        self.council = Council.objects.create(name="Test", slug="test")
+        self.field = DataField.objects.create(name="Website", slug="website")
+        self.contrib = Contribution.objects.create(
+            user=self.user,
+            council=self.council,
+            field=self.field,
+            value="http://example.com",
+        )
+        self.client.login(username="mod", password="pw")
+
+    def test_approve_awards_points(self):
+        self.client.post(
+            reverse("review_contribution", args=[self.contrib.id, "approve"]),
+            {}
+        )
+        self.contrib.refresh_from_db()
+        self.user.profile.refresh_from_db()
+        self.assertEqual(self.contrib.status, "approved")
+        self.assertEqual(self.user.profile.points, 2)
+        self.assertTrue(Notification.objects.filter(user=self.user, message__contains="accepted").exists())
+        self.assertEqual(DataChangeLog.objects.count(), 1)
+
+    def test_edit_then_approve_one_point(self):
+        self.client.post(
+            reverse("review_contribution", args=[self.contrib.id, "edit"]),
+            {"value": "http://new.com"}
+        )
+        self.client.post(
+            reverse("review_contribution", args=[self.contrib.id, "approve"]),
+            {}
+        )
+        self.user.profile.refresh_from_db()
+        self.assertEqual(self.user.profile.points, 1)
+
+    def test_reject_creates_log(self):
+        self.client.post(
+            reverse("review_contribution", args=[self.contrib.id, "reject"]),
+            {"reason": "data_incorrect"}
+        )
+        self.contrib.refresh_from_db()
+        self.user.profile.refresh_from_db()
+        self.assertEqual(self.contrib.status, "rejected")
+        self.assertEqual(self.user.profile.rejection_count, 1)
+        self.assertEqual(RejectionLog.objects.count(), 1)


### PR DESCRIPTION
## Summary
- add `edited` flag on contributions
- store rejection reasons in new `RejectionLog`
- track points and rejection counts on user profiles
- update review view to award points, log rejections, and send notifications
- allow admins to edit/reject/approve from contribution queue with modals
- create migration and tests for the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686874f981cc833198d5b4bc0359232f