### PR TITLE
Allow superusers access to God Mode

### DIFF
--- a/council_finance/views.py
+++ b/council_finance/views.py
@@ -1125,8 +1125,11 @@ def field_delete(request, slug):
 
 @login_required
 def god_mode(request):
-    """Tier 5 tool for reviewing the rejection log and blocking IPs."""
-    if request.user.profile.tier.level < 5:
+    """Tier 5 tool for reviewing the rejection log and blocking IPs.
+
+    Superusers are allowed to bypass the tier requirement entirely.
+    """
+    if not request.user.is_superuser and request.user.profile.tier.level < 5:
         raise Http404()
 
     # Configure a logger specifically for this view. The logger writes to

--- a/templates/base.html
+++ b/templates/base.html
@@ -83,7 +83,8 @@
                 <a href="{% url 'admin:index' %}" class="hover:underline">Django Admin</a>
                 <a href="{% url 'counter_definitions' %}" class="hover:underline">Counters</a>
                 <a href="{% url 'field_list' %}" class="hover:underline">Fields Manager</a>
-                {% if user.profile.tier.level >= 5 %}
+                {# Superadmins can always access God Mode regardless of tier. #}
+                {% if user.is_superuser or user.profile.tier.level >= 5 %}
                 <a href="{% url 'god_mode' %}" class="hover:underline">God Mode</a>
                 {% endif %}
             </nav>


### PR DESCRIPTION
## Summary
- show God Mode link for superusers even if their tier level is below 5
- allow superusers to access the view regardless of tier

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68696e1b859883319338a997c5f606be