### PR TITLE
Fix layout width and grid classes

### DIFF
--- a/council_finance/templates/council_finance/home.html
+++ b/council_finance/templates/council_finance/home.html
@@ -18,10 +18,8 @@
 </h2>
 <div id="homepage-counters" class="my-8 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
     {% if promoted_counters %}
-        {# The counters already sit inside a grid wrapper above. Avoid adding
-           another nested grid so column spans work as expected. #}
         {% for item in promoted_counters %}
-            <div class="bg-white shadow rounded p-5 text-center space-y-2 relative resize-counter sm:col-span-{{ item.columns }}" data-slug="{{ item.slug }}" data-default-span="{{ item.columns }}">
+            <div class="bg-gray-100 shadow rounded p-10 text-center space-y-2 relative resize-counter sm:col-span-{{ item.columns }}" data-slug="{{ item.slug }}" data-default-span="{{ item.columns }}">
                 <p class="text-sm text-gray-500 flex items-center justify-center gap-1">
                     {{ item.name }}
                     {% if item.explanation %}
@@ -30,7 +28,7 @@
                         </button>
                         {% endif %}
                     </p>
-                    <p class="text-3xl sm:text-4xl font-bold counter-value"
+                    <p class="text-4xl sm:text-4xl font-bold counter-value"
                         data-value="{{ item.raw }}"
                         data-duration="{{ item.duration }}"
                         data-precision="{{ item.precision }}"

--- a/council_finance/templates/council_finance/home.html
+++ b/council_finance/templates/council_finance/home.html
@@ -4,7 +4,9 @@
 {% block content %}
 <div id="homepage-search" class="text-center my-8">
     <form method="get" action="{% url 'home' %}" class="my-4 flex gap-2">
-        <input type="text" name="q" value="{{ query }}" placeholder="Search councils" class="border rounded px-2 py-1" />
+        {# Allow the search field to expand and occupy the remaining space so it
+           stretches across the page on larger screens. #}
+        <input type="text" name="q" value="{{ query }}" placeholder="Search councils" class="border rounded px-2 py-1 flex-grow w-full" />
         <button type="submit" class="bg-blue-600 text-white px-4 py-1 rounded">Search</button>
     </form>
 </div>
@@ -41,6 +43,9 @@
                 </div>
             {% endfor %}
         </div>
+        {# Hidden element ensures Tailwind's JIT engine generates utility
+           classes for all column spans used by the resize script. #}
+        <div class="hidden sm:col-span-1 sm:col-span-2 sm:col-span-3"></div>
     {% endif %}
 </div>
 <ul class="list-disc pl-5">

--- a/council_finance/templates/council_finance/home.html
+++ b/council_finance/templates/council_finance/home.html
@@ -4,8 +4,8 @@
 {% block content %}
 <div id="homepage-search" class="text-center my-8">
     <form method="get" action="{% url 'home' %}" class="my-4 flex gap-2">
-        {# Allow the search field to expand and occupy the remaining space so it
-           stretches across the page on larger screens. #}
+        <!-- Allow the search field to expand and occupy the remaining space so
+             it stretches across the page on larger screens. -->
         <input type="text" name="q" value="{{ query }}" placeholder="Search councils" class="border rounded px-2 py-1 flex-grow w-full" />
         <button type="submit" class="bg-blue-600 text-white px-4 py-1 rounded">Search</button>
     </form>
@@ -43,8 +43,8 @@
                 </div>
             {% endfor %}
         </div>
-        {# Hidden element ensures Tailwind's JIT engine generates utility
-           classes for all column spans used by the resize script. #}
+        <!-- Hidden element ensures Tailwind's JIT engine generates utility
+             classes for all column spans used by the resize script. -->
         <div class="hidden sm:col-span-1 sm:col-span-2 sm:col-span-3"></div>
     {% endif %}
 </div>

--- a/council_finance/templates/council_finance/home.html
+++ b/council_finance/templates/council_finance/home.html
@@ -18,12 +18,13 @@
 </h2>
 <div id="homepage-counters" class="my-8 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
     {% if promoted_counters %}
-        <div class="my-8 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6" id="promo-grid">
-            {% for item in promoted_counters %}
-                <div class="bg-white shadow rounded p-5 text-center space-y-2 relative resize-counter sm:col-span-{{ item.columns }}" data-slug="{{ item.slug }}" data-default-span="{{ item.columns }}">
-                    <p class="text-sm text-gray-500 flex items-center justify-center gap-1">
-                        {{ item.name }}
-                        {% if item.explanation %}
+        {# The counters already sit inside a grid wrapper above. Avoid adding
+           another nested grid so column spans work as expected. #}
+        {% for item in promoted_counters %}
+            <div class="bg-white shadow rounded p-5 text-center space-y-2 relative resize-counter sm:col-span-{{ item.columns }}" data-slug="{{ item.slug }}" data-default-span="{{ item.columns }}">
+                <p class="text-sm text-gray-500 flex items-center justify-center gap-1">
+                    {{ item.name }}
+                    {% if item.explanation %}
                         <button type="button" onclick="toggleInfo('info-{{ forloop.counter0 }}')" class="text-blue-600" aria-label="More info">
                             <i class="fas fa-info-circle"></i>
                         </button>
@@ -41,8 +42,7 @@
                     {% endif %}
                     <div class="absolute bottom-0 right-0 w-3 h-3 bg-gray-300 cursor-ew-resize handle"></div>
                 </div>
-            {% endfor %}
-        </div>
+        {% endfor %}
         <!-- Hidden element ensures Tailwind's JIT engine generates utility
              classes for all column spans used by the resize script. -->
         <div class="hidden sm:col-span-1 sm:col-span-2 sm:col-span-3"></div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -181,9 +181,10 @@
     </script>
     {% endif %}
 
-    {# Main content area. flex-1 allows the body flex layout to fill vertical
-       space and w-full ensures the element always spans the available width
-       while max-w-7xl caps the width on large screens. #}
+    <!-- Main content area.
+         flex-1 allows the body flex layout to fill vertical space and w-full
+         keeps the element at full width while max-w-7xl caps the size on
+         large screens. -->
     <main class="flex-1 max-w-7xl w-full mx-auto p-4">
         {% block content %}{% endblock %}
     </main>

--- a/templates/base.html
+++ b/templates/base.html
@@ -181,7 +181,10 @@
     </script>
     {% endif %}
 
-    <main class="flex-1 max-w-7xl mx-auto p-4">
+    {# Main content area. flex-1 allows the body flex layout to fill vertical
+       space and w-full ensures the element always spans the available width
+       while max-w-7xl caps the width on large screens. #}
+    <main class="flex-1 max-w-7xl w-full mx-auto p-4">
         {% block content %}{% endblock %}
     </main>
 


### PR DESCRIPTION
## Summary
- widen main content container so it doesn't shrink
- make the homepage search field stretch across the page
- ensure promoted counter spans compile for all 3 column widths

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_686abd3ad77c8331811b2d01cb782937