### PR TITLE
Add counter IDs and factoids

### DIFF
--- a/council_finance/factoids.py
+++ b/council_finance/factoids.py
@@ -1,0 +1,28 @@
+"""Simple factoid engine for counters.
+
+This module provides a helper to fetch factoids for a given counter
+slug. In a real implementation this might query the database or
+perform calculations based on financial data. For now we return
+static examples so the templates can demonstrate the feature.
+"""
+from typing import Dict, List
+import random
+
+FACTOID_DATA: Dict[str, List[Dict[str, str]]] = {
+    "total_debt": [
+        {"icon": "fa-arrow-up text-red-600", "text": "Debt up 5% vs last year"},
+        {"icon": "fa-city", "text": "Highest debt: Example Council"},
+        {"icon": "fa-city", "text": "Lowest debt: Sample Borough"},
+    ],
+    "total_reserves": [
+        {"icon": "fa-arrow-down text-green-600", "text": "Reserves down 2%"},
+    ],
+}
+
+
+def get_factoids(counter_slug: str) -> List[Dict[str, str]]:
+    """Return a list of factoids for the given counter slug."""
+    factoids = FACTOID_DATA.get(counter_slug, [])
+    # Shuffle so repeated page loads vary the order.
+    random.shuffle(factoids)
+    return factoids

--- a/council_finance/templates/council_finance/council_detail.html
+++ b/council_finance/templates/council_finance/council_detail.html
@@ -240,9 +240,17 @@ function animateCounters() {
       decimalPlaces: precision,
       separator: thousands ? ',' : '',
       prefix: showCurrency ? '£' : '',
-      easingFn: (t, b, c, d) => { t /= d; return -c * t * (t - 2) + b; }
+      easingFn: (t, b, c, d) => {
+        // cubic easing for a smoother, more natural slowdown
+        t /= d; t--; return c * (t * t * t + 1) + b;
+      }
     });
-    el.textContent = cu.formattingFn(0);
+    // show prefix and separator immediately
+    if (cu.printValue) {
+      cu.printValue(0);
+    } else {
+      el.textContent = cu.formattingFn(0);
+    }
     const container = el.parentElement;
     const factEl = container.querySelector('.counter-factoid');
     let facts = [];
@@ -261,7 +269,7 @@ function animateCounters() {
       }, 4000);
     }
     if (!cu.error) {
-      cu.start(() => { el.textContent = display; cycleFacts(); });
+      cu.start(cycleFacts);
     } else {
       el.textContent = display;
       cycleFacts();

--- a/council_finance/templates/council_finance/council_detail.html
+++ b/council_finance/templates/council_finance/council_detail.html
@@ -191,7 +191,7 @@
 {% if counters %}
 <div id="counters-grid" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 my-6">
     {% for item in counters %}
-    <div class="bg-gray-50 p-10 rounded shadow text-center {% if item.counter.headline %}md:col-span-3{% endif %}" data-counter="{{ item.counter.slug }}" {% if item.counter.headline %}style="grid-column: span 3"{% endif %}>
+    <div id="counter-{{ item.counter.slug }}" class="bg-gray-50 p-10 rounded shadow text-center {% if item.counter.headline %}md:col-span-3{% endif %}" data-counter="{{ item.counter.slug }}" {% if item.counter.headline %}style="grid-column: span 3"{% endif %}>
         <p class="text-sm text-gray-600">{{ item.counter.name }}</p>
         <p class="text-red-700 text-sm counter-error" {% if not item.error %}style="display:none"{% endif %}>{{ item.error }}</p>
         <p class="{% if item.counter.headline %}text-6xl{% else %}text-4xl{% endif %} font-bold counter-value"
@@ -202,12 +202,20 @@
            data-show-currency="{{ item.counter.show_currency }}"
            data-friendly="{{ item.counter.friendly_format }}"
            {% if item.error %}style="display:none"{% endif %}>0</p>
+        <p class="counter-factoid text-sm text-gray-600"></p>
         <p class="text-xs mt-1">{{ item.counter.explanation }}</p>
+        {% with sid='factoids-'|add:item.counter.slug %}
+        {{ item.factoids|json_script:sid }}
+        {% endwith %}
     </div>
     {% endfor %}
 </div>
 {{ default_counter_slugs|json_script:"default-slugs" }}
 <script src="{% static 'js/countUp.umd.js' %}"></script>
+<style>
+  .counter-factoid{max-height:0;overflow:hidden;transition:max-height 0.5s ease;}
+  .counter-factoid.show{max-height:3rem;}
+</style>
 <script>
 function animateCounters() {
   document.querySelectorAll('.counter-value').forEach(el => {
@@ -231,12 +239,32 @@ function animateCounters() {
       duration: dur,
       decimalPlaces: precision,
       separator: thousands ? ',' : '',
-      prefix: showCurrency ? '£' : ''
+      prefix: showCurrency ? '£' : '',
+      easingFn: (t, b, c, d) => { t /= d; return -c * t * (t - 2) + b; }
     });
+    el.textContent = cu.formattingFn(0);
+    const container = el.parentElement;
+    const factEl = container.querySelector('.counter-factoid');
+    let facts = [];
+    const script = document.getElementById('factoids-' + container.dataset.counter);
+    if (script) {
+      try { facts = JSON.parse(script.textContent); } catch(e){ facts = []; }
+    }
+    function cycleFacts(i=0){
+      if(!factEl || !facts.length) return;
+      const f = facts[i];
+      factEl.innerHTML = f.icon ? `<i class='fas ${f.icon}'></i> ${f.text}` : f.text;
+      factEl.classList.add('show');
+      setTimeout(() => {
+        factEl.classList.remove('show');
+        setTimeout(() => cycleFacts((i+1)%facts.length), 500);
+      }, 4000);
+    }
     if (!cu.error) {
-      cu.start(() => { el.textContent = display; });
+      cu.start(() => { el.textContent = display; cycleFacts(); });
     } else {
       el.textContent = display;
+      cycleFacts();
     }
   });
 }

--- a/council_finance/templates/council_finance/council_detail.html
+++ b/council_finance/templates/council_finance/council_detail.html
@@ -199,8 +199,8 @@
            data-value="{{ item.value }}"
            data-formatted="{{ item.formatted }}"
            data-precision="{{ item.counter.precision }}"
-           data-show-currency="{{ item.counter.show_currency }}"
-           data-friendly="{{ item.counter.friendly_format }}"
+           data-show-currency="{{ item.counter.show_currency|yesno:'true,false' }}"
+           data-friendly="{{ item.counter.friendly_format|yesno:'true,false' }}"
            {% if item.error %}style="display:none"{% endif %}>0</p>
         <p class="counter-factoid text-sm text-gray-600"></p>
         <p class="text-xs mt-1">{{ item.counter.explanation }}</p>
@@ -229,7 +229,8 @@ function animateCounters() {
     // Determine how the number should be formatted during the animation.
     // We honour user overrides for precision and thousands separators so
     // that the animated value looks similar to the final formatted result.
-    const showCurrency = el.dataset.showCurrency === 'true' || el.dataset.showCurrency === 'True';
+    // dataset values might be capitalised; normalise to handle both cases.
+    const showCurrency = (el.dataset.showCurrency || 'false').toLowerCase() === 'true';
     const precision = overridePrecision !== null ? parseInt(overridePrecision, 10)
       : parseInt(el.dataset.precision || '0', 10);
     const thousands = overrideThousands !== null ? overrideThousands === 'true'
@@ -241,8 +242,8 @@ function animateCounters() {
       separator: thousands ? ',' : '',
       prefix: showCurrency ? '£' : '',
       easingFn: (t, b, c, d) => {
-        // cubic easing for a smoother, more natural slowdown
-        t /= d; t--; return c * (t * t * t + 1) + b;
+        // linear deceleration - progressively slows towards the end
+        t /= d; return c * (2 - t) * t * 0.5 + b;
       }
     });
     // show prefix and separator immediately
@@ -357,9 +358,10 @@ function formatNumber(value, precision, thousands) {
 }
 
 function formatValue(value, counter) {
-  const showCurrency = counter.showCurrency === 'true' || counter.showCurrency === 'True';
+  // Normalise boolean-like strings so they work regardless of case
+  const showCurrency = (counter.showCurrency || 'false').toLowerCase() === 'true';
   const basePrecision = parseInt(counter.precision || '0', 10);
-  const baseFriendly = counter.friendly === 'true' || counter.friendly === 'True';
+  const baseFriendly = (counter.friendly || 'false').toLowerCase() === 'true';
 
   const precision = overridePrecision !== null ? parseInt(overridePrecision, 10) : basePrecision;
   const friendly = overrideFriendly !== null ? (overrideFriendly === 'true') : baseFriendly;

--- a/council_finance/templates/council_finance/home.html
+++ b/council_finance/templates/council_finance/home.html
@@ -32,8 +32,8 @@
                         data-value="{{ item.raw }}"
                         data-duration="{{ item.duration }}"
                         data-precision="{{ item.precision }}"
-                        data-show-currency="{{ item.show_currency }}"
-                        data-friendly="{{ item.friendly_format }}"
+                        data-show-currency="{{ item.show_currency|yesno:'true,false' }}"
+                        data-friendly="{{ item.friendly_format|yesno:'true,false' }}"
                         data-formatted="{{ item.formatted }}">0</p>
                     <p class="counter-factoid text-sm text-gray-600"></p>
                     {% if item.explanation %}
@@ -75,7 +75,9 @@ document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('.counter-value').forEach(el => {
         const val = parseFloat(el.dataset.value || '0');
         const dur = parseInt(el.dataset.duration || '0') / 1000;
-        const showCurrency = el.dataset.showCurrency === 'true';
+        // Dataset values may come back as "True" or "true" from the template.
+        // Normalise the string so the check works regardless of case.
+        const showCurrency = (el.dataset.showCurrency || 'false').toLowerCase() === 'true';
         const precision = parseInt(el.dataset.precision || '0');
         const thousands = showCurrency;
         const display = el.dataset.formatted || val.toLocaleString();
@@ -85,8 +87,8 @@ document.addEventListener('DOMContentLoaded', () => {
             separator: thousands ? ',' : '',
             prefix: showCurrency ? '£' : '',
             easingFn: (t, b, c, d) => {
-                // use an "ease out" cubic to give a smoother deceleration
-                t /= d; t--; return c * (t * t * t + 1) + b;
+                // simple linear deceleration: start fast and slow linearly
+                t /= d; return c * (2 - t) * t * 0.5 + b;
             }
         });
         // Print the starting value with prefix/separator so it is visible immediately

--- a/council_finance/templates/council_finance/home.html
+++ b/council_finance/templates/council_finance/home.html
@@ -19,7 +19,7 @@
 <div id="homepage-counters" class="my-8 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
     {% if promoted_counters %}
         {% for item in promoted_counters %}
-            <div class="bg-gray-100 shadow rounded p-10 text-center space-y-2 relative resize-counter sm:col-span-{{ item.columns }}" data-slug="{{ item.slug }}" data-default-span="{{ item.columns }}">
+            <div id="counter-{{ item.slug }}" class="bg-gray-100 shadow rounded p-10 text-center space-y-2 relative resize-counter sm:col-span-{{ item.columns }}" data-slug="{{ item.slug }}" data-default-span="{{ item.columns }}">
                 <p class="text-sm text-gray-500 flex items-center justify-center gap-1">
                     {{ item.name }}
                     {% if item.explanation %}
@@ -35,11 +35,15 @@
                         data-show-currency="{{ item.show_currency }}"
                         data-friendly="{{ item.friendly_format }}"
                         data-formatted="{{ item.formatted }}">0</p>
+                    <p class="counter-factoid text-sm text-gray-600"></p>
                     {% if item.explanation %}
                     <p id="info-{{ forloop.counter0 }}" class="hidden text-sm text-gray-700">{{ item.explanation }}</p>
                     {% endif %}
-                    <div class="absolute bottom-0 right-0 w-3 h-3 bg-gray-300 cursor-ew-resize handle"></div>
-                </div>
+                <div class="absolute bottom-0 right-0 w-3 h-3 bg-gray-300 cursor-ew-resize handle"></div>
+                {% with script_id='factoids-'|add:item.slug %}
+                {{ item.factoids|json_script:script_id }}
+                {% endwith %}
+            </div>
         {% endfor %}
         <!-- Hidden element ensures Tailwind's JIT engine generates utility
              classes for all column spans used by the resize script. -->
@@ -58,6 +62,10 @@
 {% endblock %}
 {% block extra_scripts %}
 <script src="{% static 'js/countUp.umd.js' %}"></script>
+<style>
+  .counter-factoid{max-height:0;overflow:hidden;transition:max-height 0.5s ease;}
+  .counter-factoid.show{max-height:3rem;}
+</style>
 <script>
 function toggleInfo(id) {
     const el = document.getElementById(id);
@@ -75,12 +83,34 @@ document.addEventListener('DOMContentLoaded', () => {
             duration: dur,
             decimalPlaces: precision,
             separator: thousands ? ',' : '',
-            prefix: showCurrency ? '£' : ''
+            prefix: showCurrency ? '£' : '',
+            easingFn: (t, b, c, d) => {
+                t /= d; return -c * t * (t - 2) + b; // easeOutQuad
+            }
         });
+        el.textContent = cu.formattingFn(0);
+        const container = el.parentElement;
+        const factEl = container.querySelector('.counter-factoid');
+        let facts = [];
+        const script = document.getElementById('factoids-' + container.dataset.slug);
+        if (script) {
+            try { facts = JSON.parse(script.textContent); } catch (e) { facts = []; }
+        }
+        function cycleFacts(i=0){
+            if(!factEl || !facts.length) return;
+            const f = facts[i];
+            factEl.innerHTML = f.icon ? `<i class='fas ${f.icon}'></i> ${f.text}` : f.text;
+            factEl.classList.add('show');
+            setTimeout(() => {
+                factEl.classList.remove('show');
+                setTimeout(() => cycleFacts((i+1)%facts.length), 500);
+            }, 4000);
+        }
         if (!cu.error) {
-            cu.start(() => { el.textContent = display; });
+            cu.start(() => { el.textContent = display; cycleFacts(); });
         } else {
             el.textContent = display;
+            cycleFacts();
         }
     });
     // Allow visitors to resize promoted counters and persist using localStorage

--- a/council_finance/templates/council_finance/home.html
+++ b/council_finance/templates/council_finance/home.html
@@ -85,10 +85,16 @@ document.addEventListener('DOMContentLoaded', () => {
             separator: thousands ? ',' : '',
             prefix: showCurrency ? '£' : '',
             easingFn: (t, b, c, d) => {
-                t /= d; return -c * t * (t - 2) + b; // easeOutQuad
+                // use an "ease out" cubic to give a smoother deceleration
+                t /= d; t--; return c * (t * t * t + 1) + b;
             }
         });
-        el.textContent = cu.formattingFn(0);
+        // Print the starting value with prefix/separator so it is visible immediately
+        if (cu.printValue) {
+            cu.printValue(0);
+        } else {
+            el.textContent = cu.formattingFn(0);
+        }
         const container = el.parentElement;
         const factEl = container.querySelector('.counter-factoid');
         let facts = [];
@@ -107,7 +113,7 @@ document.addEventListener('DOMContentLoaded', () => {
             }, 4000);
         }
         if (!cu.error) {
-            cu.start(() => { el.textContent = display; cycleFacts(); });
+            cu.start(cycleFacts);
         } else {
             el.textContent = display;
             cycleFacts();

--- a/council_finance/views.py
+++ b/council_finance/views.py
@@ -38,6 +38,7 @@ from django.conf import settings
 MANAGEMENT_TIER = 4
 
 from .models import DataField
+from .factoids import get_factoids
 from .models import (
     Council,
     FinancialYear,
@@ -143,6 +144,7 @@ def home(request):
             "friendly_format": sc.friendly_format,
             "explanation": sc.explanation,
             "columns": sc.columns,
+            "factoids": get_factoids(sc.counter.slug),
         })
 
     for gc in GroupCounter.objects.filter(promote_homepage=True):
@@ -177,6 +179,7 @@ def home(request):
             "friendly_format": gc.friendly_format,
             "explanation": "",  # groups currently lack custom explanations
             "columns": 3,  # groups default to full width for now
+            "factoids": get_factoids(gc.counter.slug),
         })
 
     context = {
@@ -282,6 +285,7 @@ def council_detail(request, slug):
                 "value": result.get("value"),
                 "formatted": result.get("formatted"),
                 "error": result.get("error"),
+                "factoids": get_factoids(counter.slug),
             }
             if counter.headline:
                 head_list.append(item)


### PR DESCRIPTION
## Summary
- add placeholder factoid engine
- attach counter factoids and IDs in templates
- tweak counter animation for currency prefix and easing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c33401e18833184be62d8839de326