### PR TITLE
Add dynamic search dropdown on homepage

### DIFF
--- a/council_finance/templates/council_finance/home.html
+++ b/council_finance/templates/council_finance/home.html
@@ -3,10 +3,13 @@
 {% block title %}Home - Council Finance Counters{% endblock %}
 {% block content %}
 <div id="homepage-search" class="text-center my-8">
-    <form method="get" action="{% url 'home' %}" class="my-4 flex gap-2">
-        <!-- Allow the search field to expand and occupy the remaining space so
-             it stretches across the page on larger screens. -->
-        <input type="text" name="q" value="{{ query }}" placeholder="Search councils" class="border rounded px-2 py-1 flex-grow w-full" />
+    <form method="get" action="{% url 'home' %}" class="my-4 flex gap-2 justify-center">
+        <!-- Wrap the input so we can position the drop-down results absolutely
+             beneath it without affecting the button layout. -->
+        <div class="relative flex-grow max-w-sm">
+            <input id="homepage-search-input" type="text" name="q" value="{{ query }}" placeholder="Search councils" class="border rounded px-2 py-1 w-full" autocomplete="off" />
+            <ul id="homepage-search-results" class="absolute left-0 right-0 bg-white text-black border rounded shadow mt-1 hidden z-10"></ul>
+        </div>
         <button type="submit" class="bg-blue-600 text-white px-4 py-1 rounded">Search</button>
     </form>
 </div>
@@ -62,6 +65,7 @@
 {% endblock %}
 {% block extra_scripts %}
 <script src="{% static 'js/countUp.umd.js' %}"></script>
+<script src="{% static 'js/live_search.js' %}"></script>
 <style>
   .counter-factoid{max-height:0;overflow:hidden;transition:max-height 0.5s ease;}
   .counter-factoid.show{max-height:3rem;}
@@ -155,6 +159,13 @@ document.addEventListener('DOMContentLoaded', () => {
         el.classList.remove('sm:col-span-1','sm:col-span-2','sm:col-span-3');
         el.classList.add(`sm:col-span-${span}`);
     }
+    // Enable live search for the homepage field using the helper shared with
+    // the header search. Results appear as the visitor types two or more
+    // letters.
+    attachLiveSearch(
+        document.getElementById('homepage-search-input'),
+        document.getElementById('homepage-search-results')
+    );
 });
 </script>
 {% endblock %}

--- a/static/js/live_search.js
+++ b/static/js/live_search.js
@@ -1,0 +1,55 @@
+// Helper to attach live search behaviour to an input element.
+// This searches the council API as the user types and shows
+// matching results in a dropdown list so the user can quickly
+// navigate to a council's detail page.
+function attachLiveSearch(input, resultsContainer) {
+    if (!input || !resultsContainer) return;
+    let timer;
+    input.addEventListener('input', () => {
+        const q = input.value.trim();
+        clearTimeout(timer);
+        if (q.length < 2) {
+            // Hide results when query is too short.
+            resultsContainer.innerHTML = '';
+            resultsContainer.classList.add('hidden');
+            return;
+        }
+        // Delay the request slightly so we do not hammer the server
+        // when the user is typing quickly.
+        timer = setTimeout(() => {
+            fetch(`/api/councils/search/?q=${encodeURIComponent(q)}`)
+                .then(r => r.json())
+                .then(items => {
+                    resultsContainer.innerHTML = '';
+                    if (!items.length) {
+                        resultsContainer.classList.add('hidden');
+                        return;
+                    }
+                    // Build a clickable list of results.
+                    items.forEach(item => {
+                        const li = document.createElement('li');
+                        li.textContent = item.name;
+                        li.dataset.slug = item.slug;
+                        li.className = 'px-2 py-1 hover:bg-gray-200 cursor-pointer';
+                        resultsContainer.appendChild(li);
+                    });
+                    resultsContainer.classList.remove('hidden');
+                })
+                .catch(() => resultsContainer.classList.add('hidden'));
+        }, 200);
+    });
+    // Navigate to the clicked result's detail page.
+    resultsContainer.addEventListener('click', e => {
+        if (e.target.dataset.slug) {
+            window.location.href = `/councils/${e.target.dataset.slug}/`;
+        }
+    });
+    // Hide the dropdown when clicking outside of the search area.
+    document.addEventListener('click', e => {
+        if (!resultsContainer.contains(e.target) && e.target !== input) {
+            resultsContainer.classList.add('hidden');
+        }
+    });
+}
+// Expose so templates can call window.attachLiveSearch
+window.attachLiveSearch = attachLiveSearch;

--- a/templates/base.html
+++ b/templates/base.html
@@ -92,6 +92,8 @@
         </div>
         {% endif %}
     </header>
+    <!-- Shared live search helper -->
+    <script src="{% static 'js/live_search.js' %}"></script>
     <script>
     const toggle = document.getElementById('notif-toggle');
     if (toggle) {
@@ -117,44 +119,12 @@
     });
 
 
-    // Live search behaviour for the main header search box.
-    const searchInput = document.getElementById('live-search-input');
-    const searchResults = document.getElementById('live-search-results');
-    if (searchInput && searchResults) {
-        searchInput.addEventListener('input', () => {
-            const q = searchInput.value.trim();
-            if (q.length < 2) {
-                searchResults.innerHTML = '';
-                searchResults.classList.add('hidden');
-                return;
-            }
-            fetch(`/api/councils/search/?q=${encodeURIComponent(q)}`)
-                .then(r => r.json())
-                .then(items => {
-                    searchResults.innerHTML = '';
-                    if (!items.length) {
-                        searchResults.classList.add('hidden');
-                        return;
-                    }
-                    items.forEach(item => {
-                        const a = document.createElement('a');
-                        a.href = `/councils/${item.slug}/`;
-                        a.textContent = item.name;
-                        a.className = 'block px-2 py-1 hover:bg-gray-200';
-                        searchResults.appendChild(a);
-                    });
-                    searchResults.classList.remove('hidden');
-                })
-                .catch(() => {
-                    searchResults.classList.add('hidden');
-                });
-        });
-        document.addEventListener('click', (e) => {
-            if (!searchResults.contains(e.target) && e.target !== searchInput) {
-                searchResults.classList.add('hidden');
-            }
-        });
-    }
+    // Attach live search to the header input. This reuses the helper defined
+    // in static/js/live_search.js so multiple inputs can share the same logic.
+    attachLiveSearch(
+        document.getElementById('live-search-input'),
+        document.getElementById('live-search-results')
+    );
     </script>
 
     {# Display one-off messages generated via Django's messages framework. #}


### PR DESCRIPTION
## Summary
- enable live search dropdown on homepage search bar
- reuse live search helper for header search box

## Testing
- `pip install -r requirements.txt`
- `python manage.py migrate`
- `pytest council_finance/tests/test_home.py::HomeViewTest::test_home_page_renders -q` *(fails: Invalid HTTP_HOST header)*

------
https://chatgpt.com/codex/tasks/task_e_686cff0b9d308331ab9050010c4976a6