### PR TITLE
Fix percent change factoid display

### DIFF
--- a/council_finance/factoids.py
+++ b/council_finance/factoids.py
@@ -9,10 +9,18 @@ from .models import Factoid
 def previous_year_label(label: str) -> Optional[str]:
     """Return the previous financial year label if parsable."""
     try:
-        base = int(str(label).split("/")[0])
+        parts = str(label).split("/")
+        if len(parts) == 2:
+            first = int(parts[0])
+            second = int(parts[1])
+            prev_first = first - 1
+            prev_second = second - 1
+            second_fmt = f"{prev_second:0{len(parts[1])}d}"
+            return f"{prev_first}/{second_fmt}"
+        base = int(parts[0])
+        return str(base - 1)
     except (TypeError, ValueError):
         return None
-    return str(base - 1)
 
 
 def get_factoids(counter_slug: str, context: Optional[Dict[str, Any]] = None) -> List[Dict[str, str]]:
@@ -59,6 +67,12 @@ def get_factoids(counter_slug: str, context: Optional[Dict[str, Any]] = None) ->
                     prev = float(context.get("previous_raw"))
                     change = (current - prev) / prev * 100
                     safe["value"] = f"{change:.1f}%"
+                    if change > 0:
+                        item["icon"] = "fa-chevron-up text-green-600"
+                    elif change < 0:
+                        item["icon"] = "fa-chevron-down text-red-600"
+                    else:
+                        item["icon"] = "fa-chevron-right text-gray-500"
                 except Exception:
                     pass
             item["text"] = item["text"].format_map(safe)

--- a/council_finance/templates/council_finance/counter_definition_form.html
+++ b/council_finance/templates/council_finance/counter_definition_form.html
@@ -97,7 +97,7 @@
         <span class="text-sm text-gray-600">Year</span>
         <select id="preview-year" class="border rounded px-2 py-1">
             {% for year in years %}
-                <option value="{{ year.label }}" {% if year.label == preview_year_label %}selected{% endif %}>{{ year.label }}</option>
+                <option value="{{ year.label }}" {% if year.label == preview_year_label %}selected{% endif %}>{{ year.display_label }}</option>
             {% endfor %}
         </select>
     </div>

--- a/council_finance/templates/council_finance/factoid_form.html
+++ b/council_finance/templates/council_finance/factoid_form.html
@@ -31,7 +31,7 @@
             <span class="text-sm text-gray-600">Year</span>
             <select id="preview-year" class="border rounded px-2 py-1">
                 {% for y in years %}
-                    <option value="{{ y.label }}">{{ y.label }}</option>
+                    <option value="{{ y.label }}">{{ y.display_label }}</option>
                 {% endfor %}
             </select>
         </div>

--- a/council_finance/tests/test_factoid_percent_change.py
+++ b/council_finance/tests/test_factoid_percent_change.py
@@ -41,3 +41,10 @@ class FactoidPercentChangeTest(TestCase):
             {"raw": 110, "previous_raw": 100},
         )
         self.assertEqual(facts[0]["text"], "10.0% change")
+
+    def test_icon_assigned(self):
+        facts = get_factoids(
+            "debt",
+            {"raw": 90, "previous_raw": 100},
+        )
+        self.assertEqual(facts[0]["icon"], "fa-chevron-down text-red-600")

--- a/council_finance/tests/test_factoid_percent_change.py
+++ b/council_finance/tests/test_factoid_percent_change.py
@@ -56,3 +56,18 @@ class FactoidPercentChangeTest(TestCase):
             {"raw": 90, "previous_raw": 0},
         )
         self.assertEqual(facts[0]["text"], "0% change")
+
+    def test_skips_when_current_missing(self):
+        """Factoids should be omitted if the current year's data is missing."""
+        facts = get_factoids(
+            "debt",
+            {"raw": None, "previous_raw": 100},
+        )
+        self.assertEqual(facts, [])
+
+    def test_skips_when_previous_missing(self):
+        facts = get_factoids(
+            "debt",
+            {"raw": 120, "previous_raw": None},
+        )
+        self.assertEqual(facts, [])

--- a/council_finance/tests/test_factoid_percent_change.py
+++ b/council_finance/tests/test_factoid_percent_change.py
@@ -48,3 +48,11 @@ class FactoidPercentChangeTest(TestCase):
             {"raw": 90, "previous_raw": 100},
         )
         self.assertEqual(facts[0]["icon"], "fa-chevron-down text-red-600")
+
+    def test_handles_zero_previous(self):
+        """When there is no previous value the function should return 0%."""
+        facts = get_factoids(
+            "debt",
+            {"raw": 90, "previous_raw": 0},
+        )
+        self.assertEqual(facts[0]["text"], "0% change")

--- a/council_finance/tests/test_factoid_placeholder.py
+++ b/council_finance/tests/test_factoid_placeholder.py
@@ -16,6 +16,6 @@ class FactoidPlaceholderTest(TestCase):
         )
         factoid.counters.add(counter)
 
-        facts = get_factoids("debt", {"value": "5%"})
+        facts = get_factoids("debt", {"raw": 105, "previous_raw": 100})
         self.assertEqual(len(facts), 1)
-        self.assertEqual(facts[0]["text"], "5% compared")
+        self.assertEqual(facts[0]["text"], "5.0% compared")

--- a/council_finance/tests/test_factoid_preview.py
+++ b/council_finance/tests/test_factoid_preview.py
@@ -49,3 +49,35 @@ class FactoidPreviewTests(TestCase):
         )
         self.assertEqual(resp.status_code, 200)
         self.assertIn("10.0%", resp.json().get("text", ""))
+
+    def test_no_previous_data_error(self):
+        """An error should be returned when prior year data is missing."""
+        url = reverse("preview_factoid")
+        resp = self.client.get(
+            url,
+            {
+                "counter": self.counter.slug,
+                "council": self.council.slug,
+                "year": self.prev_year.label,
+                "type": "percent_change",
+                "text": self.factoid_text,
+            },
+        )
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.json().get("error"), "No previous data to compare")
+
+    def test_no_current_data_error(self):
+        year_next = FinancialYear.objects.create(label="2026")
+        url = reverse("preview_factoid")
+        resp = self.client.get(
+            url,
+            {
+                "counter": self.counter.slug,
+                "council": self.council.slug,
+                "year": year_next.label,
+                "type": "percent_change",
+                "text": self.factoid_text,
+            },
+        )
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.json().get("error"), "No data for the selected year")

--- a/council_finance/tests/test_previous_year_label.py
+++ b/council_finance/tests/test_previous_year_label.py
@@ -6,5 +6,10 @@ class PreviousYearLabelTests(SimpleTestCase):
         self.assertEqual(previous_year_label('23/24'), '22/23')
         self.assertEqual(previous_year_label('2023/24'), '2022/23')
 
+    def test_dash_format(self):
+        # Mixed separators like ``2023-24`` should be interpreted the same
+        # as slash separated years.
+        self.assertEqual(previous_year_label('2023-24'), '2022/23')
+
     def test_simple_year(self):
         self.assertEqual(previous_year_label('2024'), '2023')

--- a/council_finance/tests/test_previous_year_label.py
+++ b/council_finance/tests/test_previous_year_label.py
@@ -1,0 +1,10 @@
+from django.test import SimpleTestCase
+from council_finance.factoids import previous_year_label
+
+class PreviousYearLabelTests(SimpleTestCase):
+    def test_slash_format(self):
+        self.assertEqual(previous_year_label('23/24'), '22/23')
+        self.assertEqual(previous_year_label('2023/24'), '2022/23')
+
+    def test_simple_year(self):
+        self.assertEqual(previous_year_label('2024'), '2023')


### PR DESCRIPTION
## Summary
- handle slash-separated year labels when finding the previous year
- decorate percent-change factoids with chevron icons
- add tests for previous-year label logic and icon output

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d726339208331a14bf4bf5e8e88bd