### PR TITLE
Update IP handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,11 @@ client-side using **math.js** so mistakes are surfaced immediately. Counters
 also define precision, currency display and whether large values should appear
 as friendly text like `£1m`.
 
+### Proxy configuration
+
+When `USE_X_FORWARDED_HOST` is enabled the application trusts the
+`X-Forwarded-For` header to determine the client's IP address when handling
+submissions. Deployments behind reverse proxies must ensure the proxy chain is
+configured to pass a clean header from trusted sources only; otherwise the
+recorded address can be spoofed.
+


### PR DESCRIPTION
## Summary
- trust proxy header only if USE_X_FORWARDED_HOST is enabled
- fall back to REMOTE_ADDR when the header isn't set
- document proxy configuration requirements

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_686d8be3cdc88331b2b295f68ca33f10