### PR TITLE
Add council change log view

### DIFF
--- a/council_finance/templates/council_finance/council_detail.html
+++ b/council_finance/templates/council_finance/council_detail.html
@@ -40,6 +40,7 @@
     {% if user.is_superuser or user.profile.tier.level >= 5 %}
     <a href="{% url 'council_detail' council.slug %}?tab=legacy" class="py-2 px-4 border-b-2 {% if tab == 'legacy' %}border-blue-600 font-semibold{% else %}border-transparent{% endif %}">Legacy Data</a>
     {% endif %}
+    <a href="{% url 'council_change_log' council.slug %}" class="py-2 px-4 border-b-2 {% if tab == 'log' %}border-blue-600 font-semibold{% else %}border-transparent{% endif %}">Log</a>
   </nav>
 </div>
 {% if tab == 'edit' %}

--- a/council_finance/templates/council_finance/council_log.html
+++ b/council_finance/templates/council_finance/council_log.html
@@ -1,0 +1,66 @@
+{% extends "base.html" %}
+{% load static %}
+{% block title %}Change Log - {{ council.name }}{% endblock %}
+{% block content %}
+<h1 class="text-3xl sm:text-4xl font-extrabold mb-4 pt-5 flex items-left gap-2">
+  <span class="w-8 h-8 bg-gray-300 rounded-full"></span>
+  {{ council.name }}
+</h1>
+<div class="mb-4 border-b text-center">
+  <nav class="inline-flex gap-4">
+    <a href="{% url 'council_detail' council.slug %}" class="py-2 px-4 border-b-2 {% if tab == 'view' %}border-blue-600 font-semibold{% else %}border-transparent{% endif %}">View</a>
+    <a href="{% url 'council_detail' council.slug %}?tab=edit" class="py-2 px-4 border-b-2 {% if tab == 'edit' %}border-blue-600 font-semibold{% else %}border-transparent{% endif %}">Edit</a>
+    {% if user.is_superuser or user.profile.tier.level >= 5 %}
+    <a href="{% url 'council_detail' council.slug %}?tab=legacy" class="py-2 px-4 border-b-2 {% if tab == 'legacy' %}border-blue-600 font-semibold{% else %}border-transparent{% endif %}">Legacy Data</a>
+    {% endif %}
+    <a href="{% url 'council_change_log' council.slug %}" class="py-2 px-4 border-b-2 {% if tab == 'log' %}border-blue-600 font-semibold{% else %}border-transparent{% endif %}">Log</a>
+  </nav>
+</div>
+<table class="min-w-full bg-white border mb-4">
+  <thead>
+    <tr>
+      <th class="border px-2 py-1">Field</th>
+      <th class="border px-2 py-1">Year</th>
+      <th class="border px-2 py-1">Contributor</th>
+      <th class="border px-2 py-1">Old Value</th>
+      <th class="border px-2 py-1">New Value</th>
+      <th class="border px-2 py-1">Timestamp</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for log in page_obj %}
+    <tr class="odd:bg-gray-50">
+      <td class="border px-2 py-1">{{ log.field.name }}</td>
+      <td class="border px-2 py-1 text-center">{{ log.year }}</td>
+      <td class="border px-2 py-1">
+        {% if log.contribution and log.contribution.user %}
+        {{ log.contribution.user.username }}
+        {% else %}
+        System
+        {% endif %}
+      </td>
+      <td class="border px-2 py-1">{{ log.old_value }}</td>
+      <td class="border px-2 py-1">{{ log.new_value }}</td>
+      <td class="border px-2 py-1">{{ log.created|date:'SHORT_DATETIME_FORMAT' }}</td>
+    </tr>
+    {% empty %}
+    <tr>
+      <td class="border px-2 py-1 text-center" colspan="6">No log entries.</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+<div class="flex justify-between">
+  {% if page_obj.has_previous %}
+  <a href="?page={{ page_obj.previous_page_number }}" class="underline">Previous</a>
+  {% else %}
+  <span></span>
+  {% endif %}
+  <span>Page {{ page_obj.number }} of {{ paginator.num_pages }}</span>
+  {% if page_obj.has_next %}
+  <a href="?page={{ page_obj.next_page_number }}" class="underline">Next</a>
+  {% else %}
+  <span></span>
+  {% endif %}
+</div>
+{% endblock %}

--- a/council_finance/tests/test_change_log_view.py
+++ b/council_finance/tests/test_change_log_view.py
@@ -1,0 +1,54 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+
+from council_finance.models import (
+    Council,
+    DataField,
+    FinancialYear,
+    Contribution,
+    DataChangeLog,
+)
+
+
+class ChangeLogViewTests(TestCase):
+    def setUp(self):
+        self.council = Council.objects.create(name="Town", slug="town")
+        self.user = get_user_model().objects.create_user(
+            username="alice", email="a@example.com", password="pw"
+        )
+        self.field, _ = DataField.objects.get_or_create(
+            slug="council_website", defaults={"name": "Website"}
+        )
+        self.year = FinancialYear.objects.create(label="2024")
+        # Create more than one page of log entries
+        for i in range(25):
+            contrib = Contribution.objects.create(
+                user=self.user,
+                council=self.council,
+                field=self.field,
+                year=self.year,
+                value=f"http://new{i}.com",
+                status="approved",
+            )
+            DataChangeLog.objects.create(
+                contribution=contrib,
+                council=self.council,
+                field=self.field,
+                year=self.year,
+                old_value=f"http://old{i}.com",
+                new_value=f"http://new{i}.com",
+                approved_by=self.user,
+            )
+
+    def test_detail_page_links_to_log(self):
+        resp = self.client.get(reverse("council_detail", args=["town"]))
+        self.assertContains(resp, reverse("council_change_log", args=["town"]))
+
+    def test_log_page_displays_entries(self):
+        resp = self.client.get(reverse("council_change_log", args=["town"]))
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "Page 1 of 2")
+        self.assertContains(resp, self.user.username)
+        self.assertContains(resp, "http://new24.com")
+

--- a/council_finance/urls.py
+++ b/council_finance/urls.py
@@ -47,6 +47,11 @@ urlpatterns = [
         views.council_counters,
         name="council_counters",
     ),
+    path(
+        "councils/<slug:slug>/log/",
+        views.council_change_log,
+        name="council_change_log",
+    ),
     path("councils/<slug:slug>/", views.council_detail, name="council_detail"),
     # Common menu pages
     path("leaderboards/", views.leaderboards, name="leaderboards"),

--- a/council_finance/views.py
+++ b/council_finance/views.py
@@ -12,6 +12,7 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth.hashers import make_password
 from django.contrib.auth import login
 from django.utils.crypto import get_random_string
+from django.core.paginator import Paginator
 from django.urls import reverse
 import csv
 import hashlib
@@ -385,6 +386,28 @@ def council_detail(request, slug):
         context["council_types"] = CouncilType.objects.all()
 
     return render(request, "council_finance/council_detail.html", context)
+
+
+# ---------------------------------------------------------------------------
+# Council change log view
+# ---------------------------------------------------------------------------
+def council_change_log(request, slug):
+    """Show a paginated list of approved changes for this council."""
+    council = get_object_or_404(Council, slug=slug)
+    logs = (
+        DataChangeLog.objects.filter(council=council)
+        .select_related("contribution__user", "field", "year")
+        .order_by("-created")
+    )
+    paginator = Paginator(logs, 20)
+    page = paginator.get_page(request.GET.get("page"))
+    context = {
+        "council": council,
+        "page_obj": page,
+        "paginator": paginator,
+        "tab": "log",
+    }
+    return render(request, "council_finance/council_log.html", context)
 
 
 # Additional views for common site pages


### PR DESCRIPTION
## Summary
- show a log tab on council detail pages
- list DataChangeLog entries with pagination
- test change log view

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d8beded848331abe2829aeecb9b3e