### PR TITLE
Add user badges and leaderboard

### DIFF
--- a/council_finance/models/user_profile.py
+++ b/council_finance/models/user_profile.py
@@ -80,3 +80,40 @@ class UserProfile(models.Model):
         if self.official_email_confirmed:
             completed += 1
         return int((completed / fields_total) * 100)
+
+    # --- Gamification helpers -------------------------------------------------
+
+    def level(self) -> int:
+        """Return the numeric level derived from ``points``.
+
+        Levels provide a simple progression system to reward active
+        contributors. The thresholds below can be tweaked without
+        requiring a database migration because they are computed on the
+        fly. A higher level means the user has made more approved
+        contributions.
+        """
+
+        # Ordered from highest to lowest so the first match is returned.
+        thresholds = [
+            (100, 5),
+            (50, 4),
+            (25, 3),
+            (10, 2),
+            (0, 1),
+        ]
+        for minimum, lvl in thresholds:
+            if self.points >= minimum:
+                return lvl
+        return 1
+
+    def badge(self) -> str:
+        """Human readable badge for the current :py:meth:`level`."""
+
+        badges = {
+            1: "Newcomer",
+            2: "Contributor",
+            3: "Enthusiast",
+            4: "Expert",
+            5: "Champion",
+        }
+        return badges.get(self.level(), "Newcomer")

--- a/council_finance/templates/council_finance/leaderboards.html
+++ b/council_finance/templates/council_finance/leaderboards.html
@@ -1,6 +1,28 @@
 {% extends "base.html" %}
 {% block title %}Leaderboards - Council Finance Counters{% endblock %}
 {% block content %}
-<h1 class="text-2xl font-bold mb-4">Leaderboards</h1>
-<p>This feature will display council rankings.</p>
+<h1 class="text-2xl font-bold mb-4">Top Contributors</h1>
+
+<table class="min-w-full divide-y divide-gray-200">
+    <thead>
+        <tr>
+            <th class="px-4 py-2 text-left">User</th>
+            <th class="px-4 py-2 text-left">Points</th>
+            <th class="px-4 py-2 text-left">Badge</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for profile in top_profiles %}
+        <tr class="border-b">
+            <td class="px-4 py-1">{{ profile.user.username }}</td>
+            <td class="px-4 py-1">{{ profile.points }}</td>
+            <td class="px-4 py-1">{{ profile.badge }}</td>
+        </tr>
+        {% empty %}
+        <tr>
+            <td class="px-4 py-2" colspan="3">No contributors yet.</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
 {% endblock %}

--- a/council_finance/tests/test_leaderboards.py
+++ b/council_finance/tests/test_leaderboards.py
@@ -1,0 +1,42 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+
+import django
+django.setup()
+
+from council_finance.models import UserProfile
+
+
+class LeaderboardTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        # Create two users with differing point totals so ordering can be
+        # asserted in the view test below.
+        self.alice = User.objects.create_user(
+            username="alice", email="a@example.com", password="pw"
+        )
+        self.alice.profile.points = 60
+        self.alice.profile.save()
+
+        self.bob = User.objects.create_user(
+            username="bob", email="b@example.com", password="pw"
+        )
+        self.bob.profile.points = 5
+        self.bob.profile.save()
+
+    def test_badge_and_level(self):
+        profile = self.alice.profile
+        # 60 points should place the user at level 4 with an "Expert" badge.
+        self.assertEqual(profile.level(), 4)
+        self.assertEqual(profile.badge(), "Expert")
+
+    def test_leaderboard_view_orders_by_points(self):
+        from django.test.utils import override_settings
+
+        with override_settings(ALLOWED_HOSTS=["testserver"]):
+            resp = self.client.get(reverse("leaderboards"))
+        self.assertEqual(resp.status_code, 200)
+        body = resp.content.decode()
+        # Alice should appear before Bob in the rendered HTML
+        self.assertLess(body.index("alice"), body.index("bob"))

--- a/council_finance/views.py
+++ b/council_finance/views.py
@@ -391,8 +391,17 @@ def council_detail(request, slug):
 
 
 def leaderboards(request):
-    """Placeholder leaderboards page."""
-    return render(request, "council_finance/leaderboards.html")
+    """Display the top contributors ordered by points."""
+
+    # Fetch the highest scoring profiles and include the related user object
+    # so the template can reference usernames without additional queries.
+    top_profiles = (
+        UserProfile.objects.select_related("user")
+        .order_by("-points")[:20]
+    )
+
+    context = {"top_profiles": top_profiles}
+    return render(request, "council_finance/leaderboards.html", context)
 
 
 def my_lists(request):


### PR DESCRIPTION
## Summary
- add `badge` and `level` helpers on `UserProfile`
- implement contributor leaderboard view
- show leaderboard table
- test leaderboard logic

## Testing
- `DJANGO_SETTINGS_MODULE=council_finance.settings pytest council_finance/tests/test_leaderboards.py -q`
- `pytest -q` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_686d89a350c08331be510c61852aeb77