### PR TITLE
Allow editing all council figures

### DIFF
--- a/council_finance/templates/council_finance/council_detail.html
+++ b/council_finance/templates/council_finance/council_detail.html
@@ -483,6 +483,48 @@ toggleBtn.addEventListener('click', () => {
     {% endfor %}
 </div>
 {% endif %}
+{# When in edit mode show a table with all recorded figures so users can
+   propose corrections. Each row posts to the contribution endpoint which
+   handles moderation and logging. #}
+{% if tab == 'edit' %}
+<h2 class="text-xl font-semibold mt-6">Edit Figures</h2>
+<table class="min-w-full text-sm mt-2">
+    <thead class="bg-gray-100">
+        <tr>
+            <th class="px-2 py-1 text-left">Year</th>
+            <th class="px-2 py-1 text-left">Field</th>
+            <th class="px-2 py-1 text-left">Value</th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for fig in figures %}
+        {% with key=fig.field.slug|add:'-'|add:fig.year.id %}
+        <tr class="border-b">
+            <td class="px-2 py-1">{{ fig.year.label }}</td>
+            <td class="px-2 py-1">{{ fig.field.name|capfirst }}</td>
+            <td class="px-2 py-1">
+                {% if key in pending_pairs %}
+                    <i class="fas fa-clock mr-1"></i>Pending confirmation
+                {% else %}
+                {# Submit the updated figure as a contribution. The server
+                   decides whether it should be auto-approved or queued for
+                   review based on the user's trust level. #}
+                <form method="post" action="{% url 'submit_contribution' %}" class="flex gap-2">
+                    {% csrf_token %}
+                    <input type="hidden" name="council" value="{{ council.slug }}">
+                    <input type="hidden" name="field" value="{{ fig.field.slug }}">
+                    <input type="hidden" name="year" value="{{ fig.year.id }}">
+                    <input type="text" name="value" value="{{ fig.value }}" class="border rounded p-1 flex-1">
+                    <button type="submit" class="bg-blue-600 text-white px-2 py-1 rounded">Submit</button>
+                </form>
+                {% endif %}
+            </td>
+        </tr>
+        {% endwith %}
+    {% endfor %}
+    </tbody>
+</table>
+{% endif %}
 <!-- TODO: Add a buttons for JSON and XLS/CSV exports of all data for this council for the selected financial year -->
 {% if tab == 'legacy' and figures %}
 <table class="min-w-full text-sm mt-6">

--- a/council_finance/views.py
+++ b/council_finance/views.py
@@ -332,6 +332,15 @@ def council_detail(request, slug):
                 "field__slug", flat=True
             )
         ),
+        # Keys of the form "slug-year_id" indicating pending contributions
+        # for specific figure/year pairs. This allows the edit interface to
+        # disable inputs when a submission is awaiting moderation.
+        "pending_pairs": set(
+            f"{slug}-{year_id or 'none'}"
+            for slug, year_id in Contribution.objects.filter(
+                council=council, status="pending"
+            ).values_list("field__slug", "year_id")
+        ),
     }
     if tab == "edit":
         from .models import CouncilType


### PR DESCRIPTION
## Summary
- pass pending pair information to templates for year-specific edits
- let logged-in users edit every figure on council detail pages
- add helpful comments around edit form markup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d91085c60833198ad754823190ca5