### PR TITLE
Fix homepage counter caching

### DIFF
--- a/council_finance/tests/test_volunteers.py
+++ b/council_finance/tests/test_volunteers.py
@@ -193,4 +193,5 @@ class SubmissionPointTests(TestCase):
         # Move both contributions outside the 3 week window
         Contribution.objects.all().update(created=timezone.now() - timedelta(days=22))
         self.submit()
-        self.user.profile.refresh_from_db()        self.assertEqual(self.user.profile.points, 2)
+        self.user.profile.refresh_from_db()
+        self.assertEqual(self.user.profile.points, 2)


### PR DESCRIPTION
## Summary
- compute homepage counters on demand when cache is empty
- fix syntax error in volunteers tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e4ee5332083318001742ac664cb09