### PR TITLE
Protect council location field

### DIFF
--- a/council_finance/models/field.py
+++ b/council_finance/models/field.py
@@ -14,6 +14,10 @@ PROTECTED_SLUGS = {
     # Each council should always have a website address recorded, so this
     # field is protected to prevent accidental removal.
     "council_website",
+    # The location of the council's headquarters does not change each
+    # financial year and is required for context. Treat it as immutable
+    # so submissions span all years without duplication.
+    "council_location",
 }
 
 class DataField(models.Model):


### PR DESCRIPTION
## Summary
- add `council_location` as a protected data field
- include protected fields when assessing yearless submissions

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e750e09c48331b97e7c093b4cb92d