### PR TITLE
Add CouncilNation model and link characteristic

### DIFF
--- a/council_finance/admin.py
+++ b/council_finance/admin.py
@@ -18,6 +18,7 @@ from .models.council import (
 )
 from .models.council_type import CouncilType
 from .models.council_type import CouncilCapability
+from .models.council_nation import CouncilNation
 from .models.user_profile import UserProfile
 from .models.user_follow import UserFollow
 from .models.council_follow import CouncilFollow
@@ -86,6 +87,7 @@ admin.site.register(FigureSubmission)
 admin.site.register(DebtAdjustment)
 admin.site.register(WhistleblowerReport)
 admin.site.register(ModerationLog)
+admin.site.register(CouncilNation)
 class CouncilTypeAdmin(admin.ModelAdmin):
     list_display = ("name", "display_capabilities")
 

--- a/council_finance/migrations/0040_council_nation.py
+++ b/council_finance/migrations/0040_council_nation.py
@@ -1,0 +1,63 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+def create_nations(apps, schema_editor):
+    """Populate default council nations and link the DataField."""
+    CouncilNation = apps.get_model('council_finance', 'CouncilNation')
+    DataField = apps.get_model('council_finance', 'DataField')
+    ContentType = apps.get_model('contenttypes', 'ContentType')
+
+    # Default nation names
+    defaults = [
+        'England',
+        'Wales',
+        'Scotland',
+        'Northern Ireland',
+        'Islands',
+    ]
+    for name in defaults:
+        CouncilNation.objects.get_or_create(name=name)
+
+    ct_model = ContentType.objects.get_for_model(CouncilNation)
+    DataField.objects.get_or_create(
+        slug='council_nation',
+        defaults={
+            'name': 'Council nation',
+            'category': 'characteristic',
+            'content_type': 'list',
+            'dataset_type': ct_model,
+        },
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('council_finance', '0039_characteristic_category'),
+        ('contenttypes', '0002_remove_content_type_name'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='CouncilNation',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=100, unique=True)),
+            ],
+            options={
+                'verbose_name': 'Council nation',
+                'verbose_name_plural': 'Council nations',
+            },
+        ),
+        migrations.AddField(
+            model_name='council',
+            name='council_nation',
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                to='council_finance.councilnation',
+            ),
+        ),
+        migrations.RunPython(create_nations, migrations.RunPython.noop),
+    ]

--- a/council_finance/models/__init__.py
+++ b/council_finance/models/__init__.py
@@ -7,6 +7,7 @@ from .council import (
     ModerationLog,
 )
 from .council_type import CouncilType
+from .council_nation import CouncilNation
 from .field import DataField
 from .user_profile import UserProfile
 from .trust_tier import TrustTier
@@ -39,6 +40,7 @@ __all__ = [
     'WhistleblowerReport',
     'ModerationLog',
     'CouncilType',
+    'CouncilNation',
     'DataField',
     'UserProfile',
     'UserFollow',

--- a/council_finance/models/contribution.py
+++ b/council_finance/models/contribution.py
@@ -41,6 +41,8 @@ class Contribution(models.Model):
             return self.council.website or ""
         if self.field.slug == "council_type":
             return self.council.council_type_id or ""
+        if self.field.slug == "council_nation":
+            return self.council.council_nation_id or ""
         from .council import FigureSubmission
 
         fs = FigureSubmission.objects.filter(
@@ -54,5 +56,4 @@ class Contribution(models.Model):
         return self.field.display_value(self.old_value)
 
     @property
-    def display_new_value(self) -> str:
-        return self.field.display_value(self.value)
+    def display_new_value(self) -> str:        return self.field.display_value(self.value)

--- a/council_finance/models/council.py
+++ b/council_finance/models/council.py
@@ -4,6 +4,7 @@ from django.db import models
 # independently in the admin. We import lazily to avoid circular imports
 # when Django loads models during migrations.
 from .council_type import CouncilType
+from .council_nation import CouncilNation
 from .field import DataField
 
 class Council(models.Model):
@@ -22,6 +23,14 @@ class Council(models.Model):
     # staff can manage available types.
     council_type = models.ForeignKey(
         CouncilType,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+    )
+    # Associate each council with a UK nation. Null/blank allow existing data
+    # to omit the field until populated via the admin interface.
+    council_nation = models.ForeignKey(
+        CouncilNation,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,

--- a/council_finance/models/council_nation.py
+++ b/council_finance/models/council_nation.py
@@ -1,0 +1,13 @@
+from django.db import models
+
+class CouncilNation(models.Model):
+    """Represents the UK nation a council belongs to."""
+
+    name = models.CharField(max_length=100, unique=True)
+
+    class Meta:
+        verbose_name = "Council nation"
+        verbose_name_plural = "Council nations"
+
+    def __str__(self) -> str:
+        return self.name

--- a/council_finance/models/data_change_log.py
+++ b/council_finance/models/data_change_log.py
@@ -33,6 +33,9 @@ class DataChangeLog(models.Model):
         elif self.field.slug == "council_type":
             self.council.council_type_id = self.old_value or None
             self.council.save()
+        elif self.field.slug == "council_nation":
+            self.council.council_nation_id = self.old_value or None
+            self.council.save()
         else:
             FigureSubmission.objects.update_or_create(
                 council=self.council,

--- a/council_finance/models/field.py
+++ b/council_finance/models/field.py
@@ -9,6 +9,7 @@ from django.contrib.contenttypes.models import ContentType
 # application can reliably reference them.
 CHARACTERISTIC_SLUGS = {
     "council_type",
+    "council_nation",
     "council_name",
     "population",
     "households",

--- a/council_finance/templates/council_finance/council_detail.html
+++ b/council_finance/templates/council_finance/council_detail.html
@@ -38,6 +38,18 @@
       </span>
     {% endif %}
   </div>
+  <span class="mx-2">|</span>
+  <div class="council-nation-in-header">
+    {% if council.council_nation %}
+      <span>{{ council.council_nation.name }}</span>
+    {% elif 'council_nation' in pending_slugs %}
+      <span><i class="fas fa-clock mr-1"></i>Council nation pending confirmation</span>
+    {% else %}
+      <span>
+        <a href="{% url 'council_detail' council.slug %}?tab=edit&focus=council_nation" class="text-blue-700 hover:underline">Contribute council nation</a>
+      </span>
+    {% endif %}
+  </div>
 </div>
 <div class="mb-4 border-b text-center">
   <nav class="inline-flex gap-4">
@@ -93,11 +105,35 @@
       <button type="submit" class="mt-1 bg-blue-600 text-white px-2 py-1 rounded">Submit</button>
     </form>
     {% endif %}
+    {% else %}
+    
+    {% endif %}
+  {# Council nation drop-down #}
+  {% if tab == 'edit' %}
+    {% if 'council_nation' in pending_slugs %}
+    <div class="mb-2">
+      <i class="fas fa-clock mr-1"></i>Council nation pending confirmation
+    </div>
+    {% else %}
+    <form id="field-council_nation" method="post" action="{% url 'submit_contribution' %}" class="mb-2 {% if focus == 'council_nation' %}bg-yellow-50 border border-yellow-300 p-2 rounded{% endif %}">
+      {% csrf_token %}
+      <input type="hidden" name="council" value="{{ council.slug }}">
+      <input type="hidden" name="field" value="council_nation">
+      <label class="block font-medium">Council nation</label>
+      <select name="value" class="border rounded p-1 w-full">
+        <option value="">---------</option>
+        {% for n in council_nations %}
+        <option value="{{ n.id }}" {% if council.council_nation_id == n.id %}selected{% endif %}>{{ n.name }}</option>
+        {% endfor %}
+      </select>
+      <button type="submit" class="mt-1 bg-blue-600 text-white px-2 py-1 rounded">Submit</button>
+    </form>
+    {% endif %}
   {% else %}
-   
+
   {% endif %}
-</div>
-{% if tab != 'edit' %}
+  </div>
+  {% if tab != 'edit' %}
 <div class="mt-2 flex flex-col sm:flex-row items-center gap-4 justify-between">
   <div class="flex-1 flex items-center">
     <label for="year-select" class="sr-only">Financial year</label>

--- a/council_finance/views.py
+++ b/council_finance/views.py
@@ -428,9 +428,10 @@ def council_detail(request, slug):
         "is_following": is_following,
     }
     if tab == "edit":
-        from .models import CouncilType
+        from .models import CouncilType, CouncilNation
 
         context["council_types"] = CouncilType.objects.all()
+        context["council_nations"] = CouncilNation.objects.all()
 
     return render(request, "council_finance/council_detail.html", context)
 
@@ -1742,6 +1743,9 @@ def _apply_contribution(contribution, user):
         council.save()
     elif field.slug == "council_type":
         council.council_type_id = contribution.value or None
+        council.save()
+    elif field.slug == "council_nation":
+        council.council_nation_id = contribution.value or None
         council.save()
     else:
         FigureSubmission.objects.update_or_create(


### PR DESCRIPTION
## Summary
- add `CouncilNation` model and initial data via migration
- link councils to nations with new foreign key
- update characteristic slugs
- add council nation selection in admin and council pages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686eb0a31ea083318582aed6c2c5d38d