### PR TITLE
Add dynamic input types for characteristic contributions

### DIFF
--- a/council_finance/templates/council_finance/contribute.html
+++ b/council_finance/templates/council_finance/contribute.html
@@ -107,6 +107,7 @@
     <input type="hidden" name="year" id="add-year">
     <label class="block mb-2">Value
       <input type="text" name="value" id="add-value" class="border p-2 w-full" />
+      <select name="value" id="add-value-select" class="border p-2 w-full hidden"></select>
     </label>
     <div class="text-right space-x-2">
       <button type="submit" class="bg-green-600 text-white px-4 py-1 rounded">Submit</button>
@@ -168,7 +169,35 @@ function setupAddButtons() {
       document.getElementById('add-council').value = btn.dataset.council;
       document.getElementById('add-field').value = btn.dataset.field;
       document.getElementById('add-year').value = btn.dataset.year || '';
-      document.getElementById('add-value').value = '';
+      const input = document.getElementById('add-value');
+      const select = document.getElementById('add-value-select');
+      input.value = '';
+      select.innerHTML = '';
+      input.classList.add('hidden');
+      select.classList.add('hidden');
+      input.disabled = false;
+      select.disabled = true;
+      if (btn.dataset.contentType === 'list' && btn.dataset.datasetType) {
+        // Linked list fields use a drop-down populated via AJAX so
+        // volunteers pick from valid options rather than typing free text.
+        fetch(`/fields/${btn.dataset.field}/options/`)
+          .then(resp => resp.json())
+          .then(data => {
+            data.options.forEach(opt => {
+              const option = document.createElement('option');
+              option.value = opt.id;
+              option.textContent = opt.name;
+              select.appendChild(option);
+            });
+            select.classList.remove('hidden');
+            select.disabled = false;
+          });
+      } else {
+        // URL fields trigger browser validation, everything else uses
+        // a standard text input.
+        input.type = btn.dataset.contentType === 'url' ? 'url' : 'text';
+        input.classList.remove('hidden');
+      }
       document.getElementById('add-value-modal').classList.remove('hidden');
     });
   });

--- a/council_finance/templates/council_finance/data_issues_table.html
+++ b/council_finance/templates/council_finance/data_issues_table.html
@@ -23,7 +23,8 @@
             {% if issue_type == 'missing' and not show_year %}
             <td class="px-2 py-1">
                 <button type="button" class="add-value-btn bg-blue-600 text-white px-2 py-1 rounded"
-                        data-council="{{ d.council.slug }}" data-field="{{ d.field.slug }}" data-url="{% url 'submit_contribution' %}">
+                        data-council="{{ d.council.slug }}" data-field="{{ d.field.slug }}" data-url="{% url 'submit_contribution' %}"
+                        data-content-type="{{ d.field.content_type }}" data-dataset-type="{{ d.field.dataset_type_id }}">
                     Add &amp; Earn Points
                 </button>
             </td>

--- a/council_finance/urls.py
+++ b/council_finance/urls.py
@@ -79,6 +79,7 @@ urlpatterns = [
     path("contribute/", views.contribute, name="contribute"),
     path("contribute/issues/", views.data_issues_table, name="data_issues_table"),
     path("contribute/submit/", views.submit_contribution, name="submit_contribution"),
+    path("fields/<slug:slug>/options/", views.list_field_options, name="list_field_options"),
     path("contribute/<int:pk>/<str:action>/", views.review_contribution, name="review_contribution"),
     path("submit/", views.contribute),
     path("profile/", views.my_profile, name="my_profile"),


### PR DESCRIPTION
## Summary
- enhance data issue table buttons with field metadata
- swap value input to a select when a characteristic uses a list
- validate URL values with the correct input type
- expose list field options via a small API endpoint

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686eb23a3ef88331a1e5d5dad5c9d5b3