### PR TITLE
Separate council characteristic data

### DIFF
--- a/council_finance/templates/council_finance/council_detail.html
+++ b/council_finance/templates/council_finance/council_detail.html
@@ -518,6 +518,11 @@ the correct records.
 {% endcomment %}
 {% if tab == 'edit' %}
 <h2 class="text-xl font-semibold mt-6">Edit Figures</h2>
+<h3 class="text-lg font-semibold mt-2">Characteristics</h3>
+<div id="char-table-container" class="mt-2">
+    {% include 'council_finance/edit_characteristics_table.html' with figures=characteristic_figures council=council pending_slugs=pending_slugs %}
+</div>
+<h3 class="text-lg font-semibold mt-4">Financial Data</h3>
 <div class="mt-2">
     <label for="edit-year-select" class="sr-only">Financial year</label>
     <select id="edit-year-select" class="border rounded px-2 py-1">

--- a/council_finance/templates/council_finance/edit_characteristics_table.html
+++ b/council_finance/templates/council_finance/edit_characteristics_table.html
@@ -1,0 +1,40 @@
+<table class="min-w-full text-sm mt-2">
+    <thead class="bg-gray-100">
+        <tr>
+            <th class="px-2 py-1 text-left">Field</th>
+            <th class="px-2 py-1 text-left">Value</th>
+            <th class="px-2 py-1 text-left">Helper</th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for fig in figures %}
+        <tr class="border-b">
+            <td class="px-2 py-1">{{ fig.field.name|capfirst }}</td>
+            <td class="px-2 py-1">
+                {% if fig.field.slug in pending_slugs %}
+                    <i class="fas fa-clock mr-1"></i>Pending confirmation
+                {% else %}
+                <form method="post" action="{% url 'submit_contribution' %}" class="edit-fig-form flex gap-2">
+                    {% csrf_token %}
+                    <input type="hidden" name="council" value="{{ council.slug }}">
+                    <input type="hidden" name="field" value="{{ fig.field.slug }}">
+                    <input type="hidden" name="year" value="">
+                    <input type="text" name="value" value="{{ fig.value }}" class="border rounded p-1 flex-1"
+                        {% if fig.field.content_type == 'monetary' or fig.field.content_type == 'integer' %}data-num-input{% endif %}>
+                    <button type="submit" class="bg-blue-600 text-white px-2 py-1 rounded">Submit</button>
+                </form>
+                {% endif %}
+            </td>
+            <td class="px-2 py-1 text-xs text-gray-500 num-helper">
+                {% if fig.field.content_type == 'integer' %}
+                    This should be a round number
+                {% elif fig.field.content_type == 'text' %}
+                    Input text only
+                {% elif fig.field.content_type == 'url' %}
+                    Ensure the URL starts with https://
+                {% endif %}
+            </td>
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>

--- a/council_finance/views.py
+++ b/council_finance/views.py
@@ -396,6 +396,37 @@ def council_detail(request, slug):
         
     edit_figures = figures.filter(year=edit_selected_year) if edit_selected_year else figures.none()
 
+    # Characteristic values apply across all years. Fetch the latest submission
+    # for each field so the edit interface shows a single row rather than
+    # repeating the value for every year.
+    characteristic_figures = []
+    if tab == "edit":
+        char_fields = DataField.objects.filter(category="characteristic")
+        if council.council_type_id:
+            char_fields = char_fields.filter(
+                Q(council_types__isnull=True) | Q(council_types=council.council_type)
+            )
+        else:
+            char_fields = char_fields.filter(council_types__isnull=True)
+        char_fields = char_fields.distinct()
+
+        latest = {}
+        for fs in (
+            FigureSubmission.objects.filter(council=council, field__in=char_fields)
+            .select_related("field", "year")
+            .order_by("field_id", "-year__label")
+        ):
+            # ``setdefault`` keeps the first instance for each field which is
+            # the newest thanks to the ordering above.
+            latest.setdefault(fs.field_id, fs)
+
+        default_year = FinancialYear.objects.order_by("-label").first()
+        for field in char_fields.order_by("name"):
+            fs = latest.get(field.id)
+            if not fs:
+                fs = FigureSubmission(council=council, year=default_year, field=field, value="")
+            characteristic_figures.append(fs)
+
     context = {
         "council": council,
         "figures": figures,
@@ -409,6 +440,7 @@ def council_detail(request, slug):
         "edit_years": edit_years,
         "edit_selected_year": edit_selected_year,
         "edit_figures": edit_figures,
+        "characteristic_figures": characteristic_figures,
         # Set of field slugs with pending contributions so the template
         # can show a "pending confirmation" notice in place of the form.
         "pending_slugs": set(
@@ -1974,7 +2006,7 @@ def edit_figures_table(request, slug):
     # Fetch all field definitions relevant to this council. Existing figure
     # submissions are loaded into a map so we can include blank rows for
     # missing data, allowing users to provide new figures.
-    fields = DataField.objects.all()
+    fields = DataField.objects.exclude(category="characteristic")
     if council.council_type_id:
         fields = fields.filter(
             Q(council_types__isnull=True) | Q(council_types=council.council_type)
@@ -1985,7 +2017,9 @@ def edit_figures_table(request, slug):
 
     existing = {
         (fs.field_id): fs
-        for fs in FigureSubmission.objects.filter(council=council, year=year).select_related("field", "year")
+        for fs in FigureSubmission.objects.filter(council=council, year=year)
+        .exclude(field__category="characteristic")
+        .select_related("field", "year")
     }
     figures = []
     for field in fields.order_by("name"):

--- a/static/js/edit_figures.js
+++ b/static/js/edit_figures.js
@@ -25,7 +25,7 @@ async function loadEditTable(year) {
 }
 
 function enhanceEditForms() {
-    document.querySelectorAll('#edit-table-container form.edit-fig-form').forEach(form => {
+    document.querySelectorAll('#edit-table-container form.edit-fig-form, #char-table-container form.edit-fig-form').forEach(form => {
         form.addEventListener('submit', async e => {
             e.preventDefault();
             const data = new FormData(form);
@@ -37,7 +37,7 @@ function enhanceEditForms() {
             }
         });
     });
-    document.querySelectorAll('#edit-table-container [data-num-input]').forEach(inp => {
+    document.querySelectorAll('#edit-table-container [data-num-input], #char-table-container [data-num-input]').forEach(inp => {
         const helper = inp.closest('tr').querySelector('.num-helper');
         attachNumberHelper(inp, helper);
     });
@@ -49,5 +49,6 @@ document.addEventListener('DOMContentLoaded', () => {
         sel.addEventListener('change', () => loadEditTable(sel.value));
         loadEditTable(sel.value);
     }
+    enhanceEditForms();
 });
 


### PR DESCRIPTION
## Summary
- show a dedicated characteristics table on council detail pages
- keep financial edit table focused on yearly data
- support both tables in edit JS

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686eb271d14483319482650cce4639f1