### PR TITLE
Refactor location slug

### DIFF
--- a/council_finance/data_quality.py
+++ b/council_finance/data_quality.py
@@ -31,7 +31,7 @@ def assess_data_issues() -> int:
     yearless_fields = set(
         FigureSubmission.objects.filter(year__isnull=True).values_list("field_id", flat=True)
     )
-    # Council characteristics like "population" or "council_location" only
+    # Council characteristics like "population" or "council_hq_post_code" only
     # appear once per authority. Include their IDs in ``yearless_fields`` so we
     # don't raise a missing-data issue for every financial period.
     yearless_fields.update(

--- a/council_finance/migrations/0041_refactor_council_location.py
+++ b/council_finance/migrations/0041_refactor_council_location.py
@@ -1,0 +1,16 @@
+from django.db import migrations
+
+
+def rename_field(apps, schema_editor):
+    DataField = apps.get_model('council_finance', 'DataField')
+    DataField.objects.filter(slug='council_location').update(slug='council_hq_post_code')
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('council_finance', '0040_council_nation'),
+    ]
+
+    operations = [
+        migrations.RunPython(rename_field, migrations.RunPython.noop),
+    ]

--- a/council_finance/models/field.py
+++ b/council_finance/models/field.py
@@ -16,9 +16,9 @@ CHARACTERISTIC_SLUGS = {
     # Each council should always have a website address recorded so the
     # site can link directly to their homepage.
     "council_website",
-    # Location of the council headquarters doesn't change per year and is
-    # needed to provide context for visitors.
-    "council_location",
+    # Post code for the council headquarters. Previously the slug was
+    # ``council_location`` but has been renamed for clarity.
+    "council_hq_post_code",
     # The number of elected councillors is a structural fact about a council
     # rather than a yearly statistic so this slug must remain consistent.
     "elected_members",

--- a/council_finance/tests/test_characteristic_fields.py
+++ b/council_finance/tests/test_characteristic_fields.py
@@ -27,7 +27,7 @@ class CharacteristicTabTests(TestCase):
         self.superuser = get_user_model().objects.create_superuser(
             username="admin", email="a@example.com", password="pw"
         )
-        DataField.objects.create(name="Headquarters", slug="council_location")
+        DataField.objects.create(name="Headquarters", slug="council_hq_post_code")
 
     def test_tab_visible_in_manager(self):
         self.client.login(username="admin", password="pw")
@@ -42,7 +42,7 @@ class YearlessCharacteristicTests(TestCase):
         year1 = FinancialYear.objects.create(label="2023/24")
         year2 = FinancialYear.objects.create(label="2024/25")
         council = Council.objects.create(name="Solo", slug="solo")
-        field = DataField.objects.create(name="HQ", slug="council_location")
+        field = DataField.objects.create(name="HQ", slug="council_hq_post_code")
 
         # Trigger data quality assessment without any submissions present.
         call_command("assess_data_issues")

--- a/council_finance/tests/test_data_issues_api.py
+++ b/council_finance/tests/test_data_issues_api.py
@@ -35,7 +35,7 @@ class DataIssuesApiTests(TestCase):
 
     def test_category_filter(self):
         """Filtering by category should only return matching issues."""
-        char_field = DataField.objects.create(name="HQ", slug="council_location", category="characteristic")
+        char_field = DataField.objects.create(name="HQ", slug="council_hq_post_code", category="characteristic")
         DataIssue.objects.create(council=self.council, field=char_field, issue_type="missing")
 
         url = reverse("data_issues_table") + "?type=missing&category=characteristic"

--- a/council_finance/tests/test_god_mode.py
+++ b/council_finance/tests/test_god_mode.py
@@ -56,7 +56,7 @@ class GodModeAccessTests(TestCase):
             DataIssue,
         )
 
-        field = DataField.objects.create(name="Location", slug="council_location")
+        field = DataField.objects.create(name="Location", slug="council_hq_post_code")
         council = Council.objects.create(name="Aberdeen City Council", slug="aberdeen")
         year = FinancialYear.objects.create(label="2024/25")
 

--- a/council_finance/tests/test_volunteers.py
+++ b/council_finance/tests/test_volunteers.py
@@ -157,7 +157,7 @@ class ContributeQueueTests(TestCase):
     def test_characteristics_separate_table(self):
         from council_finance.models import DataIssue
 
-        char_field = DataField.objects.create(name="HQ", slug="council_location", category="characteristic")
+        char_field = DataField.objects.create(name="HQ", slug="council_hq_post_code", category="characteristic")
         DataIssue.objects.create(council=self.council, field=char_field, issue_type="missing")
 
         resp = self.client.get(reverse("contribute"))
@@ -168,7 +168,7 @@ class ContributeQueueTests(TestCase):
         """The characteristics table should omit the year heading entirely."""
         from council_finance.models import DataIssue
 
-        char_field = DataField.objects.create(name="HQ", slug="council_location", category="characteristic")
+        char_field = DataField.objects.create(name="HQ", slug="council_hq_post_code", category="characteristic")
         DataIssue.objects.create(council=self.council, field=char_field, issue_type="missing")
 
         url = reverse("data_issues_table") + "?type=missing&category=characteristic"
@@ -179,7 +179,7 @@ class ContributeQueueTests(TestCase):
     def test_characteristics_table_has_add_buttons(self):
         from council_finance.models import DataIssue
 
-        char_field = DataField.objects.create(name="HQ", slug="council_location", category="characteristic")
+        char_field = DataField.objects.create(name="HQ", slug="council_hq_post_code", category="characteristic")
         DataIssue.objects.create(council=self.council, field=char_field, issue_type="missing")
 
         url = reverse("data_issues_table") + "?type=missing&category=characteristic"
@@ -232,13 +232,13 @@ class CharacteristicPointsTests(TestCase):
             username="charpoints", email="c@example.com", password="pw"
         )
         self.council = Council.objects.create(name="Char", slug="char")
-        self.field = DataField.objects.create(name="HQ", slug="council_location", category="characteristic")
+        self.field = DataField.objects.create(name="HQ", slug="council_hq_post_code", category="characteristic")
         self.client.login(username="charpoints", password="pw")
 
     def test_extra_points_for_characteristics(self):
         self.client.post(
             reverse("submit_contribution"),
-            {"council": "char", "field": "council_location", "value": "Town Hall"},
+            {"council": "char", "field": "council_hq_post_code", "value": "Town Hall"},
             HTTP_X_REQUESTED_WITH="XMLHttpRequest",
         )
         self.user.profile.refresh_from_db()


### PR DESCRIPTION
## Summary
- rename `council_location` slug to `council_hq_post_code`
- update characteristic slug list
- rename field usage in tests
- add migration to rename existing data

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: OperationalError: no such column: council_finance_council.council_nation_id)*

------
https://chatgpt.com/codex/tasks/task_e_686eba3b3164833196c3822a2a77569f