### PR TITLE
Add CounterAgent and SiteTotalsAgent tests

### DIFF
--- a/council_finance/tests/test_counter_agent.py
+++ b/council_finance/tests/test_counter_agent.py
@@ -1,0 +1,54 @@
+from django.test import TestCase
+from council_finance.models import (
+    Council,
+    FinancialYear,
+    DataField,
+    FigureSubmission,
+    CounterDefinition,
+)
+
+from council_finance.agents.counter_agent import CounterAgent
+
+
+class CounterAgentRunTest(TestCase):
+    """Ensure CounterAgent correctly handles valid and missing figures."""
+
+    def setUp(self):
+        # Basic objects shared across tests
+        self.council = Council.objects.create(name="Demo", slug="demo")
+        self.year = FinancialYear.objects.create(label="2025")
+        self.field = DataField.objects.create(name="Total Debt", slug="total_debt")
+        self.counter = CounterDefinition.objects.create(
+            name="Debt", slug="debt", formula="total_debt", precision=0
+        )
+        self.agent = CounterAgent()
+
+    def test_valid_figure_returns_value(self):
+        """A numeric figure should be returned with a formatted value."""
+        FigureSubmission.objects.create(
+            council=self.council,
+            year=self.year,
+            field=self.field,
+            value="123",
+        )
+        result = self.agent.run(council_slug="demo", year_label="2025")
+        self.assertEqual(result["debt"]["value"], 123.0)
+        self.assertEqual(result["debt"]["formatted"], "£123")
+
+    def test_invalid_figure_returns_no_data(self):
+        """Non-numeric figures are treated as missing."""
+        FigureSubmission.objects.create(
+            council=self.council,
+            year=self.year,
+            field=self.field,
+            value="abc",
+        )
+        result = self.agent.run(council_slug="demo", year_label="2025")
+        self.assertIsNone(result["debt"]["value"])
+        self.assertEqual(result["debt"]["formatted"], "No data")
+
+    def test_missing_figure_returns_no_data(self):
+        """When no figure exists the counter reports missing data."""
+        result = self.agent.run(council_slug="demo", year_label="2025")
+        self.assertIsNone(result["debt"]["value"])
+        self.assertEqual(result["debt"]["formatted"], "No data")

--- a/council_finance/tests/test_site_totals_agent.py
+++ b/council_finance/tests/test_site_totals_agent.py
@@ -1,0 +1,39 @@
+from django.test import TestCase
+from django.core.cache import cache
+from council_finance.models import (
+    Council,
+    FinancialYear,
+    DataField,
+    FigureSubmission,
+    CounterDefinition,
+    SiteCounter,
+    GroupCounter,
+)
+
+from council_finance.agents.site_totals_agent import SiteTotalsAgent
+
+
+class SiteTotalsAgentTest(TestCase):
+    """Verify totals are cached for both site and group counters."""
+
+    def setUp(self):
+        self.year = FinancialYear.objects.create(label="2024")
+        self.c1 = Council.objects.create(name="A", slug="a")
+        self.c2 = Council.objects.create(name="B", slug="b")
+        self.field = DataField.objects.create(name="Debt", slug="total_debt")
+        FigureSubmission.objects.create(council=self.c1, year=self.year, field=self.field, value="50")
+        FigureSubmission.objects.create(council=self.c2, year=self.year, field=self.field, value="70")
+        self.counter = CounterDefinition.objects.create(name="Debt", slug="debt", formula="total_debt", precision=0)
+        self.site_counter = SiteCounter.objects.create(name="Site Debt", slug="site-debt", counter=self.counter, year=self.year)
+        self.group_counter = GroupCounter.objects.create(name="Group Debt", slug="group-debt", counter=self.counter, year=self.year)
+        self.group_counter.councils.add(self.c1)
+        cache.clear()
+        self.agent = SiteTotalsAgent()
+
+    def test_cache_populated_with_totals(self):
+        """Running the agent stores totals for both counter types."""
+        self.agent.run()
+        site_key = f"counter_total:{self.site_counter.slug}:{self.year.label}"
+        group_key = f"counter_total:{self.group_counter.slug}:{self.year.label}"
+        self.assertEqual(cache.get(site_key), 120.0)
+        self.assertEqual(cache.get(group_key), 50.0)


### PR DESCRIPTION
## Summary
- test CounterAgent for valid, invalid and missing figures
- test SiteTotalsAgent caching including group counters

## Testing
- `pytest council_finance/tests/test_counter_agent.py council_finance/tests/test_site_totals_agent.py -q`
- `pytest -q` *(fails: ContributionApprovalTests in test_volunteers.py)*

------
https://chatgpt.com/codex/tasks/task_e_686ed8ed734083319ddf95f54326367d