### PR TITLE
Add tests for context processors and template tags

### DIFF
--- a/council_finance/tests/test_context_processors.py
+++ b/council_finance/tests/test_context_processors.py
@@ -1,0 +1,55 @@
+from django.test import TestCase, RequestFactory
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+from django.contrib.sessions.middleware import SessionMiddleware
+
+from council_finance.context_processors import compare_count, font_family
+
+
+def add_session(request):
+    """Attach a session to the request for testing."""
+    middleware = SessionMiddleware(lambda r: None)
+    middleware.process_request(request)
+    request.session.save()
+
+
+class ContextProcessorTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_compare_count_from_session(self):
+        request = self.factory.get("/")
+        add_session(request)
+        request.session["compare_basket"] = ["a", "b", "c"]
+        request.user = AnonymousUser()
+
+        context = compare_count(request)
+        self.assertEqual(context["compare_count"], 3)
+
+    def test_compare_count_default_zero(self):
+        request = self.factory.get("/")
+        add_session(request)
+        request.user = AnonymousUser()
+
+        context = compare_count(request)
+        self.assertEqual(context["compare_count"], 0)
+
+    def test_font_family_from_profile(self):
+        user = get_user_model().objects.create_user(
+            username="font", email="f@example.com", password="pw"
+        )
+        user.profile.preferred_font = "Roboto"
+        user.profile.save()
+        request = self.factory.get("/")
+        add_session(request)
+        request.user = user
+
+        context = font_family(request)
+        self.assertEqual(context["font_family"], "Roboto")
+
+    def test_font_family_default(self):
+        request = self.factory.get("/")
+        add_session(request)
+        request.user = AnonymousUser()
+
+        self.assertEqual(font_family(request)["font_family"], "Cairo")

--- a/council_finance/tests/test_templatetags.py
+++ b/council_finance/tests/test_templatetags.py
@@ -1,0 +1,69 @@
+from django.test import TestCase, RequestFactory
+from django.template import Context
+from django.contrib.auth import get_user_model
+from django.db.utils import OperationalError
+from unittest.mock import patch
+
+from council_finance.templatetags.extras import get_item
+from council_finance.templatetags.notifications import (
+    unread_count,
+    recent_notifications,
+    profile_progress,
+)
+from council_finance.models import Notification
+
+
+class ExtrasTagTests(TestCase):
+    def test_get_item(self):
+        self.assertEqual(get_item({"a": 1}, "a"), 1)
+        self.assertIsNone(get_item("foo", "a"))
+
+
+class NotificationTagTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = get_user_model().objects.create_user(
+            username="note", email="n@example.com", password="pw"
+        )
+
+    def _context(self):
+        request = self.factory.get("/")
+        return Context({"user": self.user, "request": request})
+
+    def test_unread_count(self):
+        Notification.objects.create(user=self.user, message="hi")
+        Notification.objects.create(user=self.user, message="bye", read=True)
+        ctx = self._context()
+        self.assertEqual(unread_count(ctx), 1)
+
+    def test_unread_count_missing_table(self):
+        with patch.object(self.user.notifications, "filter", side_effect=OperationalError):
+            ctx = self._context()
+            self.assertEqual(unread_count(ctx), 0)
+
+    def test_recent_notifications_limited(self):
+        n1 = Notification.objects.create(user=self.user, message="1")
+        n2 = Notification.objects.create(user=self.user, message="2")
+        n3 = Notification.objects.create(user=self.user, message="3")
+        ctx = self._context()
+        notes = recent_notifications(ctx, limit=2)
+        self.assertEqual(notes[0], n3)
+        self.assertEqual(notes[1], n2)
+
+    def test_recent_notifications_missing_table(self):
+        # Patch QuerySet.order_by to simulate a missing table error
+        with patch("django.db.models.query.QuerySet.order_by", side_effect=OperationalError):
+            ctx = self._context()
+            self.assertEqual(recent_notifications(ctx), [])
+
+    def test_profile_progress(self):
+        self.user.profile.postcode = "AA1 1AA"
+        self.user.profile.political_affiliation = "Party"
+        self.user.profile.save()
+        ctx = self._context()
+        self.assertGreater(profile_progress(ctx), 0)
+
+    def test_profile_progress_missing_table(self):
+        with patch.object(self.user.profile, "completion_percent", side_effect=OperationalError):
+            ctx = self._context()
+            self.assertEqual(profile_progress(ctx), 0)


### PR DESCRIPTION
## Summary
- add coverage for context processors
- add coverage for template tags including error handling

## Testing
- `pytest -q` *(fails: test_volunteers.py::ContributionApprovalTests::test_low_tier_pending, test_volunteers.py::ContributionApprovalTests::test_missing_history_no_auto_approve, test_volunteers.py::ContributionApprovalTests::test_standard_post_redirects)*

------
https://chatgpt.com/codex/tasks/task_e_686eddb7a2c48331a8576b58dc86287a