### PR TITLE
Add share link API and restore settings

### DIFF
--- a/council_finance/templates/council_finance/council_detail.html
+++ b/council_finance/templates/council_finance/council_detail.html
@@ -138,15 +138,24 @@
             Copy Link
           </button>
           <script>
-            document.getElementById('share-link').addEventListener('click', () => {
-              const baseUrl = window.location.origin + window.location.pathname;
+            document.getElementById('share-link').addEventListener('click', async () => {
+              const endpoint = new URL('{% url "generate_share_link" council.slug %}', window.location.origin);
               const year = document.getElementById('year-select').value;
               const selectedCounters = Array.from(document.querySelectorAll('#counters-grid [data-counter]'))
                 .filter(el => el.style.display !== 'none')
                 .map(el => el.dataset.counter);
-              const params = new URLSearchParams({ year, counters: selectedCounters.join(',') });
-              const shareUrl = `${baseUrl}?${params.toString()}`;
-              document.getElementById('share-url').value = shareUrl;
+              endpoint.searchParams.set('year', year);
+              endpoint.searchParams.set('counters', selectedCounters.join(','));
+              endpoint.searchParams.set('precision', precisionSelect.value || '');
+              endpoint.searchParams.set('thousands', thousandsCheck.checked);
+              endpoint.searchParams.set('friendly', friendlyCheck.checked);
+              try {
+                const resp = await fetch(endpoint, {headers: {'X-Requested-With': 'XMLHttpRequest'}});
+                const data = await resp.json();
+                document.getElementById('share-url').value = data.url || '';
+              } catch (e) {
+                document.getElementById('share-url').value = 'Error generating link';
+              }
             });
             document.getElementById('copy-share-link').addEventListener('click', () => {
               const shareUrl = document.getElementById('share-url');
@@ -185,6 +194,7 @@
     {% endfor %}
 </div>
 {{ default_counter_slugs|json_script:"default-slugs" }}
+{% if share_data %}{{ share_data|json_script:"share-data" }}{% endif %}
 <script src="{% static 'js/countUp.umd.js' %}"></script>
 <style>
   .counter-factoid{max-height:0;overflow:hidden;transition:max-height 0.5s ease;}
@@ -312,6 +322,32 @@ const friendlyCheck = document.getElementById('friendly-check');
 let overridePrecision = localStorage.getItem(`precision_${councilSlug}`);
 let overrideThousands = localStorage.getItem(`thousands_${councilSlug}`);
 let overrideFriendly = localStorage.getItem(`friendly_${councilSlug}`);
+
+const shareEl = document.getElementById('share-data');
+let sharePrefs = null;
+if (shareEl) {
+  try { sharePrefs = JSON.parse(shareEl.textContent); } catch (e) { sharePrefs = null; }
+}
+if (sharePrefs) {
+  if (sharePrefs.precision !== undefined && sharePrefs.precision !== null) {
+    overridePrecision = sharePrefs.precision;
+    localStorage.setItem(`precision_${councilSlug}`, sharePrefs.precision);
+  }
+  if (sharePrefs.thousands !== undefined) {
+    overrideThousands = sharePrefs.thousands ? 'true' : 'false';
+    localStorage.setItem(`thousands_${councilSlug}`, overrideThousands);
+  }
+  if (sharePrefs.friendly !== undefined) {
+    overrideFriendly = sharePrefs.friendly ? 'true' : 'false';
+    localStorage.setItem(`friendly_${councilSlug}`, overrideFriendly);
+  }
+  if (Array.isArray(sharePrefs.counters)) {
+    localStorage.setItem(`counters_${councilSlug}`, JSON.stringify(sharePrefs.counters));
+  }
+  if (sharePrefs.year) {
+    document.getElementById('year-select').value = sharePrefs.year;
+  }
+}
 
 if (overridePrecision !== null) precisionSelect.value = overridePrecision;
 if (overrideThousands !== null) thousandsCheck.checked = overrideThousands === 'true';

--- a/council_finance/tests/test_share_links.py
+++ b/council_finance/tests/test_share_links.py
@@ -1,0 +1,41 @@
+from django.test import TestCase
+from django.urls import reverse
+
+from council_finance.models import Council, FinancialYear, DataField, CounterDefinition
+
+
+class ShareLinkTests(TestCase):
+    def setUp(self):
+        self.council = Council.objects.create(name="Test", slug="test")
+        self.year = FinancialYear.objects.create(label="2024")
+        field = DataField.objects.create(slug="total_debt", name="Total Debt")
+        CounterDefinition.objects.create(
+            name="Debt",
+            slug="debt",
+            formula="total_debt",
+            precision=0,
+            show_currency=False,
+        )
+
+    def test_generate_link_returns_url(self):
+        url = reverse("generate_share_link", args=["test"])
+        resp = self.client.get(
+            url,
+            {
+                "year": "2024",
+                "counters": "debt",
+                "precision": "1",
+                "thousands": "true",
+                "friendly": "true",
+            },
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("?share=", resp.json()["url"])
+
+    def test_link_restores_settings(self):
+        url = reverse("generate_share_link", args=["test"])
+        resp = self.client.get(url, {"year": "2024", "counters": "debt"})
+        link = resp.json()["url"]
+        resp2 = self.client.get(link)
+        self.assertEqual(resp2.context["share_data"]["counters"], ["debt"])
+        self.assertEqual(resp2.context["share_data"]["year"], "2024")

--- a/council_finance/urls.py
+++ b/council_finance/urls.py
@@ -48,6 +48,11 @@ urlpatterns = [
         name="council_counters",
     ),
     path(
+        "councils/<slug:slug>/share/",
+        views.generate_share_link,
+        name="generate_share_link",
+    ),
+    path(
         "councils/<slug:slug>/edit-table/",
         views.edit_figures_table,
         name="edit_figures_table",


### PR DESCRIPTION
## Summary
- add API endpoint to create signed share URLs
- decode `share` token in council detail view
- update template JS to fetch the share link and restore saved options
- insert tests verifying the share link round trip

## Testing
- `pytest council_finance/tests/test_share_links.py -q`
- `pytest -q` *(fails: ContributionApprovalTests.test_low_tier_pending, ContributionApprovalTests.test_missing_history_no_auto_approve, ContributionApprovalTests.test_standard_post_redirects)*

------
https://chatgpt.com/codex/tasks/task_e_686eddcce9988331a7653ec2ae50ad89