### PR TITLE
Remove manual Django setup calls from tests

### DIFF
--- a/council_finance/tests/test_home.py
+++ b/council_finance/tests/test_home.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 from django.urls import reverse
-import django
-django.setup()
+# django.setup() isn't needed when running tests with pytest-django
+
 
 from council_finance.models import Council, FinancialYear, DataField, FigureSubmission
 

--- a/council_finance/tests/test_leaderboards.py
+++ b/council_finance/tests/test_leaderboards.py
@@ -1,9 +1,7 @@
 from django.test import TestCase
 from django.urls import reverse
 from django.contrib.auth import get_user_model
-
-import django
-django.setup()
+# django.setup() is handled by pytest-django when tests run
 
 from council_finance.models import UserProfile
 

--- a/council_finance/tests/test_my_lists.py
+++ b/council_finance/tests/test_my_lists.py
@@ -1,8 +1,7 @@
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse
-import django
-django.setup()
+# pytest-django configures Django; explicit setup is unnecessary
 
 from council_finance.models import CouncilList, Council
 

--- a/council_finance/tests/test_profile.py
+++ b/council_finance/tests/test_profile.py
@@ -1,8 +1,7 @@
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse
-import django
-django.setup()
+# django.setup() is unnecessary under pytest-django
 
 from unittest.mock import patch
 

--- a/council_finance/tests/test_search_api.py
+++ b/council_finance/tests/test_search_api.py
@@ -1,7 +1,6 @@
 from django.test import TestCase
 from django.urls import reverse
-import django
-django.setup()
+# pytest-django sets up Django for tests automatically
 
 class SearchApiTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- remove `django.setup()` from several tests
- let pytest-django handle Django initialization

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: 3 failed, 105 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686eddd5d9bc8331b0a0ca7a4a200220