### PR TITLE
Add JSON output to God Mode activity log

### DIFF
--- a/council_finance/templates/council_finance/god_mode.html
+++ b/council_finance/templates/council_finance/god_mode.html
@@ -76,6 +76,7 @@
       <th class="border px-2 py-1">Request</th>
       <th class="border px-2 py-1">Response</th>
       <th class="border px-2 py-1">Extra</th>
+      <th class="border px-2 py-1">JSON</th>
     </tr>
   </thead>
   <tbody id="activity-log-body"></tbody>

--- a/council_finance/tests/test_activity_log_json.py
+++ b/council_finance/tests/test_activity_log_json.py
@@ -1,0 +1,31 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+
+from council_finance.models import ActivityLog
+
+class ActivityLogJsonTests(TestCase):
+    def setUp(self):
+        self.superuser = get_user_model().objects.create_superuser(
+            username="boss", email="boss@example.com", password="secret"
+        )
+        self.client.login(username="boss", password="secret")
+        ActivityLog.objects.create(
+            user=self.superuser,
+            page="/test",
+            activity="unit_test",
+            button="x",
+            action="do",
+            request="POST",
+            response="ok",
+            extra=""
+        )
+
+    def test_json_field_in_api(self):
+        resp = self.client.get(reverse("activity_log_entries"))
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()["results"][0]
+        self.assertIn("json", data)
+        import json
+        obj = json.loads(data["json"])
+        self.assertEqual(obj["activity"], "unit_test")

--- a/static/js/activity_log.js
+++ b/static/js/activity_log.js
@@ -18,6 +18,8 @@
         data.results.forEach(row => {
           const tr = document.createElement('tr');
           tr.className = 'odd:bg-gray-50';
+          // Each row also includes a JSON representation so that admins
+          // can easily copy a machine-readable log entry.
           tr.innerHTML = `
             <td class="border px-2 py-1">${row.time}</td>
             <td class="border px-2 py-1">${row.user}</td>
@@ -28,7 +30,8 @@
             <td class="border px-2 py-1">${row.action}</td>
             <td class="border px-2 py-1">${row.request}</td>
             <td class="border px-2 py-1">${row.response}</td>
-            <td class="border px-2 py-1">${row.extra}</td>`;
+            <td class="border px-2 py-1">${row.extra}</td>
+            <td class="border px-2 py-1 whitespace-pre-wrap text-xs">${row.json}</td>`;
           tableBody.appendChild(tr);
         });
       });


### PR DESCRIPTION
## Summary
- extend `log_activity` to capture caller info and store as JSON
- return a `json` field from the activity log API
- display JSON in the God Mode activity log table
- add regression test for the API

## Testing
- `pip install -q -r requirements.txt`
- `pytest council_finance/tests/test_activity_log_json.py::ActivityLogJsonTests::test_json_field_in_api -q`
- `pytest -q` *(fails: ContributionApprovalTests in volunteers)*

------
https://chatgpt.com/codex/tasks/task_e_686ee4ea82808331902b5a8b4f694b77