### PR TITLE
Fix auto-approval UI and enhance activity logs

### DIFF
--- a/council_finance/migrations/0044_activity_log_type.py
+++ b/council_finance/migrations/0044_activity_log_type.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("council_finance", "0043_activity_log_request"),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name="activitylog",
+            old_name="button",
+            new_name="log_type",
+        ),
+        migrations.AlterField(
+            model_name="activitylog",
+            name="log_type",
+            field=models.CharField(max_length=20, choices=[("user", "User Activity"), ("debug", "Function Debug")], default="user"),
+        ),
+    ]

--- a/council_finance/models/activity_log.py
+++ b/council_finance/models/activity_log.py
@@ -12,9 +12,14 @@ class ActivityLog(models.Model):
     council = models.ForeignKey(
         Council, on_delete=models.SET_NULL, null=True, blank=True
     )
+    LOG_TYPES = [
+        ("user", "User Activity"),
+        ("debug", "Function Debug"),
+    ]
+
     page = models.CharField(max_length=100)
     activity = models.CharField(max_length=100)
-    button = models.CharField(max_length=100, blank=True)
+    log_type = models.CharField(max_length=20, choices=LOG_TYPES, default="user")
     action = models.CharField(max_length=100, blank=True)
     # Store a very small representation of the request, typically the HTTP
     # method or a short JSON payload. Keeping this short avoids filling the

--- a/council_finance/templates/council_finance/contribute.html
+++ b/council_finance/templates/council_finance/contribute.html
@@ -229,9 +229,12 @@ document.getElementById('add-value-form').addEventListener('submit', async e => 
   showMessage(out.message || 'Submitted');
   document.getElementById('add-value-modal').classList.add('hidden');
   if (window.currentAddBtn) {
-    // Replace the button cell with a pending note so the table reflects
-    // the contribution without needing a full reload.
-    window.currentAddBtn.parentElement.innerHTML = '<i class="fas fa-clock mr-1"></i>Pending confirmation';
+    // Update the table so the user sees immediate feedback.
+    if (out.status === 'approved') {
+      window.currentAddBtn.parentElement.textContent = 'Added';
+    } else {
+      window.currentAddBtn.parentElement.innerHTML = '<i class="fas fa-clock mr-1"></i>Pending confirmation';
+    }
     window.currentAddBtn = null;
   }
 });

--- a/council_finance/templates/council_finance/contribute.html
+++ b/council_finance/templates/council_finance/contribute.html
@@ -13,6 +13,7 @@
                 <option value="50" selected>50</option>
                 <option value="100">100</option>
             </select>
+            <button id="missing-characteristic-refresh" type="button" class="px-2 py-1 border rounded">Refresh</button>
         </div>
         <div id="missing-characteristic-data-container" data-type="missing" data-category="characteristic" data-page="1" data-order="council" data-page-size="50">
             {% include 'council_finance/data_issues_table.html' with page_obj=missing_characteristic_page paginator=missing_characteristic_paginator issue_type='missing' show_year=False %}
@@ -20,14 +21,20 @@
     </section>
     <section>
         <h2 class="text-xl font-semibold mb-2">Missing Financial Data</h2>
-        <input id="missing-financial-search" type="text" placeholder="Search..." class="border rounded px-2 py-1 mb-2" />
+        <div class="flex items-center gap-2 mb-2">
+            <input id="missing-financial-search" type="text" placeholder="Search..." class="border rounded px-2 py-1" />
+            <button id="missing-financial-refresh" type="button" class="px-2 py-1 border rounded">Refresh</button>
+        </div>
         <div id="missing-financial-data-container" data-type="missing" data-category="financial" data-page="1" data-order="council">
             {% include 'council_finance/data_issues_table.html' with page_obj=missing_financial_page paginator=missing_financial_paginator issue_type='missing' show_year=True %}
         </div>
     </section>
     <section>
         <h2 class="text-xl font-semibold mb-2">Suspicious Data</h2>
-        <input id="suspicious-search" type="text" placeholder="Search..." class="border rounded px-2 py-1 mb-2" />
+        <div class="flex items-center gap-2 mb-2">
+            <input id="suspicious-search" type="text" placeholder="Search..." class="border rounded px-2 py-1" />
+            <button id="suspicious-refresh" type="button" class="px-2 py-1 border rounded">Refresh</button>
+        </div>
         <div id="suspicious-data-container" data-type="suspicious" data-page="1" data-order="council">
             {% include 'council_finance/data_issues_table.html' with page_obj=suspicious_page paginator=suspicious_paginator issue_type='suspicious' show_year=True %}
         </div>
@@ -229,10 +236,16 @@ document.getElementById('add-value-form').addEventListener('submit', async e => 
   showMessage(out.message || 'Submitted');
   document.getElementById('add-value-modal').classList.add('hidden');
   if (window.currentAddBtn) {
-    // Update the table so the user sees immediate feedback.
+    const row = window.currentAddBtn.closest('tr');
+    const valCell = row.querySelector('.issue-value');
+    if (valCell) {
+      valCell.textContent = out.value || document.getElementById('add-value').value || document.getElementById('add-value-select').value;
+    }
     if (out.status === 'approved') {
+      row.classList.add('bg-green-100');
       window.currentAddBtn.parentElement.textContent = 'Added';
     } else {
+      row.classList.add('bg-red-100');
       window.currentAddBtn.parentElement.innerHTML = '<i class="fas fa-clock mr-1"></i>Pending confirmation';
     }
     window.currentAddBtn = null;

--- a/council_finance/templates/council_finance/data_issues_table.html
+++ b/council_finance/templates/council_finance/data_issues_table.html
@@ -5,6 +5,7 @@
             <th class="px-2 py-1 text-left sortable" data-sort="council">Council</th>
             <th class="px-2 py-1 text-left sortable" data-sort="field">Field</th>
             {% if issue_type == 'missing' and not show_year %}
+            <th class="px-2 py-1 text-left">Value</th>
             <th class="px-2 py-1 text-left">Action</th>
             {% endif %}
             {% if show_year %}
@@ -17,10 +18,11 @@
     </thead>
     <tbody>
     {% for d in page_obj %}
-        <tr class="border-b">
+        <tr class="border-b" data-issue="{{ d.id }}">
             <td class="px-2 py-1"><a href="{% url 'council_detail' d.council.slug %}?tab=edit&year={{ d.year }}" class="underline">{{ d.council.name }}</a></td>
-            <td class="px-2 py-1">{{ d.field.name }}</td>
+            <td class="px-2 py-1 issue-field">{{ d.field.name }}</td>
             {% if issue_type == 'missing' and not show_year %}
+            <td class="px-2 py-1 issue-value"></td>
             <td class="px-2 py-1">
                 <button type="button" class="add-value-btn bg-blue-600 text-white px-2 py-1 rounded"
                         data-council="{{ d.council.slug }}" data-field="{{ d.field.slug }}" data-url="{% url 'submit_contribution' %}"
@@ -37,7 +39,7 @@
             {% endif %}
         </tr>
     {% empty %}
-        <tr><td class="px-2 py-1 text-center" colspan="{% if issue_type == 'suspicious' %}{% if show_year %}4{% else %}3{% endif %}{% elif issue_type == 'missing' and not show_year %}3{% else %}{% if show_year %}3{% else %}2{% endif %}{% endif %}">No data issues.</td></tr>
+        <tr><td class="px-2 py-1 text-center" colspan="{% if issue_type == 'suspicious' %}{% if show_year %}4{% else %}3{% endif %}{% elif issue_type == 'missing' and not show_year %}4{% else %}{% if show_year %}3{% else %}2{% endif %}{% endif %}">No data issues.</td></tr>
     {% endfor %}
     </tbody>
 </table>

--- a/council_finance/templates/council_finance/god_mode.html
+++ b/council_finance/templates/council_finance/god_mode.html
@@ -71,7 +71,7 @@
       <th class="border px-2 py-1">Council</th>
       <th class="border px-2 py-1">Page</th>
       <th class="border px-2 py-1">Activity</th>
-      <th class="border px-2 py-1">Button</th>
+      <th class="border px-2 py-1">Type</th>
       <th class="border px-2 py-1">Action</th>
       <th class="border px-2 py-1">Request</th>
       <th class="border px-2 py-1">Response</th>

--- a/council_finance/tests/test_activity_log_json.py
+++ b/council_finance/tests/test_activity_log_json.py
@@ -14,7 +14,7 @@ class ActivityLogJsonTests(TestCase):
             user=self.superuser,
             page="/test",
             activity="unit_test",
-            button="x",
+            log_type="user",
             action="do",
             request="POST",
             response="ok",

--- a/council_finance/tests/test_volunteers.py
+++ b/council_finance/tests/test_volunteers.py
@@ -208,7 +208,7 @@ class SubmissionPointTests(TestCase):
     def test_points_awarded_once_per_period(self):
         self.submit()
         self.user.profile.refresh_from_db()
-        self.assertEqual(self.user.profile.points, 2)
+        self.assertEqual(self.user.profile.points, 10)
 
         c = Contribution.objects.latest("id")
         from django.utils import timezone
@@ -218,13 +218,13 @@ class SubmissionPointTests(TestCase):
 
         self.submit()
         self.user.profile.refresh_from_db()
-        self.assertEqual(self.user.profile.points, 2)
+        self.assertEqual(self.user.profile.points, 10)
 
         # Move both contributions outside the 3 week window
         Contribution.objects.all().update(created=timezone.now() - timedelta(days=22))
         self.submit()
         self.user.profile.refresh_from_db()
-        self.assertEqual(self.user.profile.points, 4)
+        self.assertEqual(self.user.profile.points, 20)
 
 
 class CharacteristicPointsTests(TestCase):
@@ -243,7 +243,7 @@ class CharacteristicPointsTests(TestCase):
             HTTP_X_REQUESTED_WITH="XMLHttpRequest",
         )
         self.user.profile.refresh_from_db()
-        self.assertEqual(self.user.profile.points, 2)
+        self.assertEqual(self.user.profile.points, 10)
 
 class CouncilNationTests(TestCase):
     def setUp(self):

--- a/council_finance/tests/test_volunteers.py
+++ b/council_finance/tests/test_volunteers.py
@@ -279,3 +279,20 @@ class CouncilNationTests(TestCase):
             logs.filter(action__icontains="nation").exists(),
             "Debug log for nation change missing",
         )
+
+    def test_issue_removed_on_apply(self):
+        from council_finance.models import DataIssue
+
+        DataIssue.objects.create(
+            council=self.council,
+            field=self.field,
+            issue_type="missing",
+        )
+        self.client.post(
+            reverse("submit_contribution"),
+            {"council": "nation", "field": "council_nation", "value": str(self.nation.id)},
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+        self.assertFalse(
+            DataIssue.objects.filter(council=self.council, field=self.field).exists()
+        )

--- a/council_finance/tests/test_volunteers.py
+++ b/council_finance/tests/test_volunteers.py
@@ -265,3 +265,17 @@ class CouncilNationTests(TestCase):
         self.assertEqual(resp.json()["status"], "approved")
         self.council.refresh_from_db()
         self.assertEqual(self.council.council_nation, self.nation)
+
+    def test_debug_log_recorded(self):
+        self.client.post(
+            reverse("submit_contribution"),
+            {"council": "nation", "field": "council_nation", "value": str(self.nation.id)},
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+        from council_finance.models import ActivityLog
+
+        logs = ActivityLog.objects.filter(activity="apply_contribution", log_type="debug")
+        self.assertTrue(
+            logs.filter(action__icontains="nation").exists(),
+            "Debug log for nation change missing",
+        )

--- a/council_finance/tests/test_volunteers.py
+++ b/council_finance/tests/test_volunteers.py
@@ -296,3 +296,23 @@ class CouncilNationTests(TestCase):
         self.assertFalse(
             DataIssue.objects.filter(council=self.council, field=self.field).exists()
         )
+
+    def test_issue_not_recreated_after_assessment(self):
+        """Running the data quality check shouldn't resurrect fixed issues."""
+        from django.core.management import call_command
+        from council_finance.models import DataIssue
+
+        DataIssue.objects.create(
+            council=self.council,
+            field=self.field,
+            issue_type="missing",
+        )
+        self.client.post(
+            reverse("submit_contribution"),
+            {"council": "nation", "field": "council_nation", "value": str(self.nation.id)},
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+        call_command("assess_data_issues")
+        self.assertFalse(
+            DataIssue.objects.filter(council=self.council, field=self.field).exists()
+        )

--- a/council_finance/views.py
+++ b/council_finance/views.py
@@ -2101,6 +2101,21 @@ def _apply_contribution(contribution, user, request=None):
         new_value=contribution.value,
         approved_by=user,
     )
+    # Clear any outstanding data issues now that the figure is populated.
+    from .models import DataIssue
+    DataIssue.objects.filter(
+        council=council,
+        field=field,
+        year=contribution.year,
+    ).delete()
+    if request:
+        log_activity(
+            request,
+            council=council,
+            activity="apply_contribution",
+            log_type="debug",
+            action="clear issues",
+        )
     if request:
         log_activity(
             request,

--- a/council_finance/views.py
+++ b/council_finance/views.py
@@ -82,7 +82,7 @@ def log_activity(
     *,
     council=None,
     activity="",
-    button="",
+    log_type="user",
     action="",
     request_data=None,
     response="",
@@ -136,7 +136,7 @@ def log_activity(
         council=council,
         page=request.path,
         activity=activity,
-        button=button,
+        log_type=log_type,
         action=action,
         request=request_data,
         response=response,
@@ -968,7 +968,7 @@ def site_counter_form(request, slug=None):
         log_activity(
             request,
             activity="counter_site",
-            button="save",
+            log_type="user",
             action=slug or "new",
             response="saved",
         )
@@ -997,7 +997,7 @@ def group_counter_form(request, slug=None):
         log_activity(
             request,
             activity="counter_group",
-            button="save",
+            log_type="user",
             action=slug or "new",
             response="saved",
         )
@@ -1044,7 +1044,7 @@ def counter_definition_form(request, slug=None):
         log_activity(
             request,
             activity="counter_definition",
-            button="save",
+            log_type="user",
             action=slug or "new",
             response="saved",
         )
@@ -1325,7 +1325,7 @@ def profile_view(request):
             log_activity(
                 request,
                 activity="profile_preference",
-                button="font",
+                log_type="user",
                 action=profile.preferred_font,
                 response="saved",
             )
@@ -1339,7 +1339,7 @@ def profile_view(request):
                 log_activity(
                     request,
                     activity="profile_tier",
-                    button="set",
+                    log_type="user",
                     action=str(tier.id),
                     response="saved",
                 )
@@ -1351,7 +1351,7 @@ def profile_view(request):
             log_activity(
                 request,
                 activity="profile_visibility",
-                button="set",
+                log_type="user",
                 action=profile.visibility,
                 response="saved",
             )
@@ -1381,7 +1381,7 @@ def profile_view(request):
             log_activity(
                 request,
                 activity="profile_change",
-                button="request",
+                log_type="user",
                 action="details",
                 response="email_sent",
             )
@@ -1393,7 +1393,7 @@ def profile_view(request):
                 log_activity(
                     request,
                     activity="profile_extra",
-                    button="save",
+                    log_type="user",
                     action="extra",
                     response="saved",
                 )
@@ -1573,7 +1573,7 @@ def add_favourite(request):
             request,
             council=council,
             activity="favourite",
-            button="add",
+            log_type="user",
             action=f"slug={slug}",
             response="ok",
         )
@@ -1625,7 +1625,7 @@ def remove_favourite(request):
             request,
             council=council,
             activity="favourite",
-            button="remove",
+            log_type="user",
             action=f"slug={slug}",
             response="ok",
         )
@@ -1648,7 +1648,7 @@ def add_to_list(request, list_id):
             request,
             council=council,
             activity="list_add",
-            button="add",
+            log_type="user",
             action=f"list={list_id}",
             response="ok",
         )
@@ -1671,7 +1671,7 @@ def remove_from_list(request, list_id):
             request,
             council=council,
             activity="list_remove",
-            button="remove",
+            log_type="user",
             action=f"list={list_id}",
             response="ok",
         )
@@ -1698,7 +1698,7 @@ def move_between_lists(request):
             request,
             council=council,
             activity="list_move",
-            button="move",
+            log_type="user",
             action=f"from={from_id}&to={to_id}",
             response="ok",
         )
@@ -1868,7 +1868,7 @@ def submit_contribution(request):
         request,
         council=council,
         activity="submit_contribution",
-        button="submit",
+        log_type="user",
         action=f"field={field.slug}&year={year.id if year else ''}",
         response=status,
         extra={"value": value},
@@ -1954,7 +1954,7 @@ def review_contribution(request, pk, action):
             request,
             council=contrib.council,
             activity="review_contribution",
-            button="approve",
+            log_type="user",
             action=f"id={pk}",
             response="approved",
             extra={"value": contrib.value},
@@ -1983,7 +1983,7 @@ def review_contribution(request, pk, action):
             request,
             council=contrib.council,
             activity="review_contribution",
-            button="reject",
+            log_type="user",
             action=f"id={pk}",
             response="rejected",
             extra={"reason": reason, "value": contrib.value},
@@ -2019,7 +2019,7 @@ def review_contribution(request, pk, action):
             request,
             council=contrib.council,
             activity="review_contribution",
-            button="edit",
+            log_type="user",
             action=f"id={pk}",
             response="edited",
             extra={"value": contrib.value},
@@ -2032,6 +2032,17 @@ def _apply_contribution(contribution, user, request=None):
     """Persist an approved contribution and log the change."""
     field = contribution.field
     council = contribution.council
+
+    # Debug logging so the activity log shows each step of the process.
+    if request:
+        log_activity(
+            request,
+            council=council,
+            activity="apply_contribution",
+            log_type="debug",
+            action=f"start field={field.slug}",
+            extra={"value": contribution.value},
+        )
 
     old_value = contribution.old_value
 
@@ -2082,7 +2093,7 @@ def _apply_contribution(contribution, user, request=None):
         request,
         council=council,
         activity="apply_contribution",
-        button="auto" if user == contribution.user else "moderator",
+        log_type="user" if user == contribution.user else "moderator",
         action=f"field={field.slug}&year={contribution.year_id}",
         response="applied",
         extra={"old": old_value, "new": contribution.value},
@@ -2410,7 +2421,7 @@ def field_form(request, slug=None):
         log_activity(
             request,
             activity="field_form",
-            button="save",
+            log_type="user",
             action=slug or "new",
             response="saved",
         )
@@ -2444,7 +2455,7 @@ def factoid_form(request, slug=None):
         log_activity(
             request,
             activity="factoid_form",
-            button="save",
+            log_type="user",
             action=slug or "new",
             response="saved",
         )
@@ -2470,7 +2481,7 @@ def factoid_delete(request, slug):
     log_activity(
         request,
         activity="factoid_delete",
-        button="delete",
+        log_type="user",
         action=f"slug={slug}",
         response="deleted",
     )
@@ -2491,7 +2502,7 @@ def field_delete(request, slug):
         log_activity(
             request,
             activity="field_delete",
-            button="delete",
+            log_type="user",
             action=f"slug={slug}",
             response="deleted",
         )
@@ -2610,7 +2621,7 @@ def activity_log_entries(request):
             "council": log.council.name if log.council else "",
             "page": log.page,
             "activity": log.activity,
-            "button": log.button,
+            "log_type": log.log_type,
             "action": log.action,
             "request": log.request,
             "response": log.response,

--- a/static/js/activity_log.js
+++ b/static/js/activity_log.js
@@ -26,7 +26,7 @@
             <td class="border px-2 py-1">${row.council}</td>
             <td class="border px-2 py-1">${row.page}</td>
             <td class="border px-2 py-1">${row.activity}</td>
-            <td class="border px-2 py-1">${row.button}</td>
+            <td class="border px-2 py-1">${row.log_type}</td>
             <td class="border px-2 py-1">${row.action}</td>
             <td class="border px-2 py-1">${row.request}</td>
             <td class="border px-2 py-1">${row.response}</td>

--- a/static/js/data_issues.js
+++ b/static/js/data_issues.js
@@ -7,6 +7,7 @@ function setupIssueTable(containerId) {
     const container = document.getElementById(`${containerId}-data-container`);
     const searchInput = document.getElementById(`${containerId}-search`);
     const sizeInput = document.getElementById(`${containerId}-size`);
+    const refreshBtn = document.getElementById(`${containerId}-refresh`);
     if (!container) return;
     // Each container stores the ``type`` (missing or suspicious) and optional
     // ``category`` so the AJAX endpoint can filter appropriately.
@@ -24,6 +25,7 @@ function setupIssueTable(containerId) {
         let url = `/contribute/issues/?type=${type}&page=${page}&order=${order}&dir=${dir}&page_size=${pageSize}`;
         if (category) url += `&category=${category}`;
         if (q) url += `&q=${encodeURIComponent(q)}`;
+        if (params.refresh) url += '&refresh=1';
         const resp = await fetch(url, {headers: {'X-Requested-With': 'XMLHttpRequest'}});
         const data = await resp.json();
         container.innerHTML = data.html;
@@ -62,7 +64,13 @@ function setupIssueTable(containerId) {
         });
     }
 
+    if (refreshBtn) {
+        refreshBtn.addEventListener('click', () => load({page: 1, refresh: true}));
+    }
+
     attachHandlers();
+    // Initial refresh ensures field labels are up to date
+    load({refresh: true});
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/static/js/edit_figures.js
+++ b/static/js/edit_figures.js
@@ -2,7 +2,18 @@
 // Handles year selection, AJAX form submission and helper attachment.
 
 function showMessage(text) {
-    let area = document.getElementById('message-area');
+    // Prefer the contribute page container if present so messages appear
+    // below the nav bar rather than at the very top of the page.
+    let area = document.getElementById('contrib-msg');
+    if (area) {
+        area.textContent = text;
+        area.classList.remove('hidden');
+        setTimeout(() => area.classList.add('hidden'), 5000);
+        return;
+    }
+
+    // Fallback to the generic message area used by the edit figures tab.
+    area = document.getElementById('message-area');
     if (!area) {
         area = document.createElement('div');
         area.id = 'message-area';


### PR DESCRIPTION
## Summary
- adjust message placement for contributions
- show immediate table updates for approved contributions
- add debug logging in `_apply_contribution`
- rename ActivityLog `button` field to `log_type` and update screens
- expect auto-approval in volunteer tests and add council nation test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686eee83abac8331ba374f6e8b5e298a