### PR TITLE
Add real-time queue worker

### DIFF
--- a/static/js/data_issues.js
+++ b/static/js/data_issues.js
@@ -15,9 +15,8 @@ function setupIssueTable(containerId) {
     const category = container.dataset.category;
 
     let timer;
-    // Store the last set of issue IDs so the periodic checker can report what
-    // changed after each refresh. This helps volunteers see when their
-    // contributions remove items from the queue.
+    // Track the issues shown on screen so polling can report any that were
+    // added or removed since the last refresh.
     let currentIds = new Set();
 
     async function load(params = {}) {
@@ -73,9 +72,21 @@ function setupIssueTable(containerId) {
         if (params.check && before) {
             const after = gatherInfo();
             const removed = Object.keys(before).filter(id => !after[id]);
+            const added = Object.keys(after).filter(id => !before[id]);
+
             if (removed.length) {
                 removed.forEach(id => {
+                    // When an issue disappears we tell the user so they know
+                    // their recent contribution removed it from the queue.
                     showMessage(`${before[id]} resolved: removing from queue`);
+                });
+            }
+
+            if (added.length) {
+                added.forEach(id => {
+                    // Inform volunteers when new issues appear so they know
+                    // their queue is updating in real time.
+                    showMessage(`New issue: ${after[id]}`);
                 });
             }
         }
@@ -91,6 +102,7 @@ function setupIssueTable(containerId) {
             const field = row.querySelector('.issue-field')?.textContent.trim();
             info[id] = `${field} for ${council}`;
         });
+        // Store the set so the next refresh can compare against it.
         currentIds = new Set(Object.keys(info));
         return info;
     }

--- a/static/js/data_issues.js
+++ b/static/js/data_issues.js
@@ -15,9 +15,6 @@ function setupIssueTable(containerId) {
     const category = container.dataset.category;
 
     let timer;
-    // Track the issues shown on screen so polling can report any that were
-    // added or removed since the last refresh.
-    let currentIds = new Set();
 
     async function load(params = {}) {
         const order = params.order || container.dataset.order || 'council';
@@ -102,8 +99,6 @@ function setupIssueTable(containerId) {
             const field = row.querySelector('.issue-field')?.textContent.trim();
             info[id] = `${field} for ${council}`;
         });
-        // Store the set so the next refresh can compare against it.
-        currentIds = new Set(Object.keys(info));
         return info;
     }
 
@@ -147,7 +142,8 @@ function setupIssueTable(containerId) {
     // without forcing a full page reload. Volunteers see a brief spinner and a
     // message describing any issues removed since the last check.
     setInterval(() => {
-        showMessage('<i class="fas fa-sync-alt fa-spin mr-1"></i> Checking data...');
+        // Display a brief spinner so volunteers know the system is polling.
+        showMessage('<i class="fas fa-sync-alt fa-spin mr-1"></i> Checking data...', true);
         load({page: container.dataset.page, refresh: true, check: true});
     }, 60000);
 }

--- a/static/js/edit_figures.js
+++ b/static/js/edit_figures.js
@@ -1,16 +1,20 @@
 // JS helpers for the Edit Figures tab on council detail pages.
 // Handles year selection, AJAX form submission and helper attachment.
 
-function showMessage(text) {
+// Display a transient notification to the user.
+// ``html`` controls whether the message is treated as HTML markup or plain text.
+function showMessage(text, html = false) {
     // Prefer the contribute page container if present so messages appear
     // below the nav bar rather than at the very top of the page.
     let area = document.getElementById('contrib-msg');
     if (area) {
-        // Allow basic markup (like icons) in the message so status updates can
-        // include small spinners or other indicators. Using ``innerHTML`` here
-        // lets callers pass HTML strings while still showing plain text when no
-        // markup is provided.
-        area.innerHTML = text;
+        // Use ``innerHTML`` only when explicitly allowed so normal messages
+        // remain plain text and cannot accidentally inject markup.
+        if (html) {
+            area.innerHTML = text;
+        } else {
+            area.textContent = text;
+        }
         area.classList.remove('hidden');
         setTimeout(() => area.classList.add('hidden'), 5000);
         return;
@@ -25,9 +29,21 @@ function showMessage(text) {
     }
     const div = document.createElement('div');
     div.className = 'message mb-2 p-2 bg-blue-50 border border-blue-300 text-blue-900 rounded flex justify-between items-start';
-    div.innerHTML = `<span>${text}</span><button type="button" class="close ml-2" aria-label="Dismiss">&times;</button>`;
+    const span = document.createElement('span');
+    if (html) {
+        span.innerHTML = text;
+    } else {
+        span.textContent = text;
+    }
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'close ml-2';
+    btn.setAttribute('aria-label', 'Dismiss');
+    btn.innerHTML = '&times;';
+    div.appendChild(span);
+    div.appendChild(btn);
     area.appendChild(div);
-    div.querySelector('.close').addEventListener('click', () => div.remove());
+    btn.addEventListener('click', () => div.remove());
     setTimeout(() => div.remove(), 8000);
 }
 

--- a/static/js/edit_figures.js
+++ b/static/js/edit_figures.js
@@ -6,7 +6,11 @@ function showMessage(text) {
     // below the nav bar rather than at the very top of the page.
     let area = document.getElementById('contrib-msg');
     if (area) {
-        area.textContent = text;
+        // Allow basic markup (like icons) in the message so status updates can
+        // include small spinners or other indicators. Using ``innerHTML`` here
+        // lets callers pass HTML strings while still showing plain text when no
+        // markup is provided.
+        area.innerHTML = text;
         area.classList.remove('hidden');
         setTimeout(() => area.classList.add('hidden'), 5000);
         return;


### PR DESCRIPTION
## Summary
- enhance `showMessage` to allow basic markup
- poll data issue queues every minute
- show messages for removed issues during polling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872252f4df08331a74e3baff2546c29