### PR TITLE
Optimize contribute page load to reduce DB locks

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 ```
+Whenever `requirements.txt` changes (for example, after pulling a new version of
+the code) run the install command again so new packages like **Django Channels**
+are available.
 
 2. Apply database migrations whenever pulling new code:
 
@@ -35,6 +38,12 @@ python manage.py runserver
 ```
 
 You can then access the admin at `http://localhost:8000/admin/` using the credentials created above.
+
+When using SQLite with the real-time features enabled, you might see
+`database is locked` errors if multiple connections try to write at the same
+time. The default configuration now increases the SQLite timeout to 20 seconds
+to mitigate this. If the problem persists, stop any background processes that
+may be accessing the database.
 
 ## Adding councils and figures
 

--- a/council_finance/settings.py
+++ b/council_finance/settings.py
@@ -68,6 +68,9 @@ DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
         "NAME": BASE_DIR / "db.sqlite3",
+        # Increase the lock timeout to reduce "database is locked" errors
+        # when multiple connections (such as WebSockets) access SQLite.
+        "OPTIONS": {"timeout": 20},
     }
 }
 

--- a/council_finance/templates/council_finance/contribute.html
+++ b/council_finance/templates/council_finance/contribute.html
@@ -17,6 +17,7 @@
         <option value="missing" data-category="characteristic">Missing Characteristics</option>
         <option value="suspicious">Suspicious</option>
         <option value="pending">Pending Approval</option>
+<<<<<<< HEAD
       </select>
       <select id="issues-size" class="border rounded px-2 py-1">
         <option value="25">25</option>
@@ -25,6 +26,18 @@
       </select>
     </div>
     <div id="issues-data-container" data-page="1" data-order="council" data-dir="asc" data-page-size="50">
+=======
+      </select>
+      <select id="issues-size" class="border rounded px-2 py-1">
+        <option value="25">25</option>
+        <option value="50" selected>50</option>
+        <option value="100">100</option>
+      </select>
+      <button id="issues-refresh" type="button" class="px-2 py-1 border rounded">Refresh</button>
+      <span id="issues-loading" class="hidden" role="status" aria-live="polite">Loading...</span>
+    </div>
+    <div id="issues-data-container" data-page="1" data-order="council" data-dir="asc" data-page-size="50" aria-live="polite">
+>>>>>>> c109bc6a9be31a5a84d55a77720be4ffbb9e286c
       {% include 'council_finance/data_issues_table.html' with page_obj=page_obj paginator=paginator issue_type='missing' show_year=True %}
     </div>
     <h2 class="sr-only">Missing Financial Data</h2>
@@ -46,10 +59,15 @@ if (!localStorage.getItem('seenTutorial')) {
 document.getElementById('edit-cancel').addEventListener('click', () => document.getElementById('edit-modal').classList.add('hidden'));
 document.getElementById('reject-cancel').addEventListener('click', () => document.getElementById('reject-modal').classList.add('hidden'));
 document.getElementById('add-cancel').addEventListener('click', () => document.getElementById('add-value-modal').classList.add('hidden'));
+<<<<<<< HEAD
 document.addEventListener('issueTableUpdated', () => {
   document.querySelectorAll('.reject-btn').forEach(btn => {
     btn.onclick = e => { e.preventDefault(); document.getElementById('reject-form').action = btn.dataset.url; document.getElementById('reject-modal').classList.remove('hidden');};
   });
 });
+=======
+// Re-attach moderator reject buttons after each table update
+attachRejectButtons();
+>>>>>>> c109bc6a9be31a5a84d55a77720be4ffbb9e286c
 </script>
 {% endblock %}

--- a/council_finance/views.py
+++ b/council_finance/views.py
@@ -731,7 +731,9 @@ def contribute(request):
     from .models import DataIssue, UserProfile
     from .data_quality import assess_data_issues
 
-    assess_data_issues()
+    # Rebuilding the DataIssue table can take a while and may lock the
+    # SQLite database. Avoid doing so automatically on every page load.
+    # Volunteers can trigger a refresh via AJAX if needed.
 
     from django.core.paginator import Paginator
 

--- a/static/js/data_issues.js
+++ b/static/js/data_issues.js
@@ -1,5 +1,11 @@
+<<<<<<< HEAD
 // Real-time contribute table helper
 // Connects via WebSocket and refreshes when the server broadcasts updates.
+=======
+// Real-time contribute table helper.
+// Loads issue data via AJAX and updates when WebSocket events arrive.
+// The heavy database refresh is triggered manually to avoid lock ups.
+>>>>>>> c109bc6a9be31a5a84d55a77720be4ffbb9e286c
 
 function contributeTable() {
   const container = document.getElementById('issues-data-container');
@@ -7,6 +13,11 @@ function contributeTable() {
   const searchInput = document.getElementById('issues-search');
   const typeSelect = document.getElementById('issues-type');
   const sizeInput = document.getElementById('issues-size');
+<<<<<<< HEAD
+=======
+  const loading = document.getElementById('issues-loading');
+  const refreshBtn = document.getElementById('issues-refresh');
+>>>>>>> c109bc6a9be31a5a84d55a77720be4ffbb9e286c
 
   let timer;
 
@@ -20,6 +31,10 @@ function contributeTable() {
     let url = `/contribute/issues/?type=${type}&page=${page}&order=${order}&dir=${dir}&page_size=${pageSize}`;
     if (q) url += `&q=${encodeURIComponent(q)}`;
     if (params.refresh) url += '&refresh=1';
+<<<<<<< HEAD
+=======
+    if (loading) loading.classList.remove('hidden');
+>>>>>>> c109bc6a9be31a5a84d55a77720be4ffbb9e286c
     const resp = await fetch(url, {headers:{'X-Requested-With':'XMLHttpRequest'}});
     const data = await resp.json();
     container.innerHTML = data.html;
@@ -28,6 +43,11 @@ function contributeTable() {
     container.dataset.page = page;
     container.dataset.pageSize = pageSize;
     attachHandlers();
+<<<<<<< HEAD
+=======
+    attachRejectButtons();
+    if (loading) loading.classList.add('hidden');
+>>>>>>> c109bc6a9be31a5a84d55a77720be4ffbb9e286c
   }
 
   function attachHandlers() {
@@ -51,7 +71,15 @@ function contributeTable() {
   typeSelect.addEventListener('change', () => load({page:1}));
   sizeInput.addEventListener('change', () => load({page:1, pageSize:sizeInput.value}));
 
+<<<<<<< HEAD
   load({refresh:true});
+=======
+  // Initial load without triggering a heavy refresh
+  load();
+  if (refreshBtn) {
+    refreshBtn.addEventListener('click', () => load({refresh:true}));
+  }
+>>>>>>> c109bc6a9be31a5a84d55a77720be4ffbb9e286c
 
   // WebSocket connection for real-time updates
   const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
@@ -62,6 +90,19 @@ function contributeTable() {
   });
 }
 
+<<<<<<< HEAD
+=======
+function attachRejectButtons() {
+  document.querySelectorAll('.reject-btn').forEach(btn => {
+    btn.onclick = e => {
+      e.preventDefault();
+      document.getElementById('reject-form').action = btn.dataset.url;
+      document.getElementById('reject-modal').classList.remove('hidden');
+    };
+  });
+}
+
+>>>>>>> c109bc6a9be31a5a84d55a77720be4ffbb9e286c
 async function updateModeratorPanel() {
   const panel = document.getElementById('moderator-panel');
   if (!panel) return;

--- a/static/js/edit_figures.js
+++ b/static/js/edit_figures.js
@@ -1,12 +1,20 @@
 // JS helpers for the Edit Figures tab on council detail pages.
 // Handles year selection, AJAX form submission and helper attachment.
 
-function showMessage(text) {
+// Display a transient notification to the user.
+// ``html`` controls whether the message is treated as HTML markup or plain text.
+function showMessage(text, html = false) {
     // Prefer the contribute page container if present so messages appear
     // below the nav bar rather than at the very top of the page.
     let area = document.getElementById('contrib-msg');
     if (area) {
-        area.textContent = text;
+        // Use ``innerHTML`` only when explicitly allowed so normal messages
+        // remain plain text and cannot accidentally inject markup.
+        if (html) {
+            area.innerHTML = text;
+        } else {
+            area.textContent = text;
+        }
         area.classList.remove('hidden');
         setTimeout(() => area.classList.add('hidden'), 5000);
         return;
@@ -21,9 +29,21 @@ function showMessage(text) {
     }
     const div = document.createElement('div');
     div.className = 'message mb-2 p-2 bg-blue-50 border border-blue-300 text-blue-900 rounded flex justify-between items-start';
-    div.innerHTML = `<span>${text}</span><button type="button" class="close ml-2" aria-label="Dismiss">&times;</button>`;
+    const span = document.createElement('span');
+    if (html) {
+        span.innerHTML = text;
+    } else {
+        span.textContent = text;
+    }
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'close ml-2';
+    btn.setAttribute('aria-label', 'Dismiss');
+    btn.innerHTML = '&times;';
+    div.appendChild(span);
+    div.appendChild(btn);
     area.appendChild(div);
-    div.querySelector('.close').addEventListener('click', () => div.remove());
+    btn.addEventListener('click', () => div.remove());
     setTimeout(() => div.remove(), 8000);
 }
 


### PR DESCRIPTION
## Summary
- avoid running `assess_data_issues()` every time the contribute page loads
- add manual refresh button and loading indicator
- update JS to show spinner and reattach moderator buttons

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6872406d2714833198ec3f34f0f3ee97