### PR TITLE
Remove duplicate setup_django

### DIFF
--- a/check_templates.py
+++ b/check_templates.py
@@ -18,13 +18,8 @@ from pathlib import Path
 from collections import defaultdict
 
 def setup_django():
-    """Setup Django environment"""
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'council_finance.settings')
-    django.setup()
-
-def setup_django():
-    """Setup Django environment"""
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'council_finance.settings')
+    """Set up the Django environment once."""
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "council_finance.settings")
     django.setup()
 
 def parse_arguments():


### PR DESCRIPTION
## Summary
- deduplicate `setup_django()` in the template checker

## Testing
- `python manage.py test_templates --check-syntax-only` *(fails: argument conflict)*

------
https://chatgpt.com/codex/tasks/task_e_687a6988dc088331a2865b7d00cf9cf7