### PR TITLE
Update path logic in fix_imports

### DIFF
--- a/fix_imports.py
+++ b/fix_imports.py
@@ -1,14 +1,26 @@
 #!/usr/bin/env python3
-"""
-Script to fix relative imports in general.py after views module refactoring.
+"""Fix relative imports in ``general.py`` after refactoring.
+
+Usage::
+
+    python fix_imports.py
+
+The script locates ``general.py`` relative to its own location and replaces
+old relative imports with absolute ones under ``council_finance``. This is
+useful when modules are moved and import paths need updating.
 """
 
 import re
+from pathlib import Path
 
 def fix_imports():
-    filepath = r"f:\mikerouse\Documents\Projects\Council Finance Counters\v3\cfc\council_finance\views\general.py"
+    # Compute the path to ``general.py`` relative to this script. This keeps the
+    # script portable regardless of the working directory.
+    script_dir = Path(__file__).resolve().parent
+    filepath = script_dir / "council_finance" / "views" / "general.py"
     
-    with open(filepath, 'r', encoding='utf-8') as f:
+    # Read the current file contents.
+    with filepath.open("r", encoding="utf-8") as f:
         content = f.read()
     
     # Replace relative imports with absolute imports
@@ -26,7 +38,8 @@ def fix_imports():
     for pattern, replacement in replacements:
         content = re.sub(pattern, replacement, content)
     
-    with open(filepath, 'w', encoding='utf-8') as f:
+    # Overwrite the file with the updated imports.
+    with filepath.open("w", encoding="utf-8") as f:
         f.write(content)
     
     print("Fixed relative imports in general.py")


### PR DESCRIPTION
## Summary
- make fix_imports.py compute general.py's path relative to the script
- expand the docstring with usage instructions

## Testing
- `python check_templates.py`
- `pytest -q` *(fails: cannot import 'font_family', database access not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_687a6994b17c8331b51f84521787f681