### PR TITLE
Add variable name helper for DataField

### DIFF
--- a/council_finance/models/factoid.py
+++ b/council_finance/models/factoid.py
@@ -156,7 +156,7 @@ class FactoidTemplate(models.Model):
         from .field import DataField
         for field_name in self.referenced_fields:
             try:
-                DataField.objects.get(variable_name=field_name)
+                DataField.from_variable_name(field_name)
             except DataField.DoesNotExist:
                 errors.append(f"Referenced field '{field_name}' does not exist")
         

--- a/council_finance/models/field.py
+++ b/council_finance/models/field.py
@@ -83,6 +83,18 @@ class DataField(models.Model):
     required = models.BooleanField(default=False)
 
     @property
+    def variable_name(self) -> str:
+        """Return the slug formatted for template variables."""
+        return self.slug.replace('-', '_')
+
+    @classmethod
+    def from_variable_name(cls, name: str):
+        """Look up a field using the template variable name."""
+        base = name.split('.')[-1]
+        slug = base.replace('_', '-')
+        return cls.objects.get(slug=slug)
+
+    @property
     def is_protected(self) -> bool:
         """Return True if this field's slug is immutable."""
         return self.slug in PROTECTED_SLUGS

--- a/council_finance/services/factoid_engine.py
+++ b/council_finance/services/factoid_engine.py
@@ -41,7 +41,7 @@ class FactoidEngine:
         """
         try:
             # Try to get the field definition
-            data_field = DataField.objects.get(variable_name=field_name)
+            data_field = DataField.from_variable_name(field_name)
             
             # Handle different field categories
             if data_field.category == 'characteristic':
@@ -64,9 +64,10 @@ class FactoidEngine:
     def _get_characteristic_value(self, field_name: str, council: Council, year: FinancialYear) -> Any:
         """Get value from council characteristics"""
         try:
+            slug = DataField.from_variable_name(field_name).slug
             characteristic = CouncilCharacteristic.objects.filter(
                 council=council,
-                field__variable_name=field_name,
+                field__slug=slug,
                 year=year
             ).first()
             
@@ -85,9 +86,10 @@ class FactoidEngine:
     def _get_financial_value(self, field_name: str, council: Council, year: FinancialYear) -> Any:
         """Get value from financial figures"""
         try:
+            slug = DataField.from_variable_name(field_name).slug
             figure = FinancialFigure.objects.filter(
                 council=council,
-                field__variable_name=field_name,
+                field__slug=slug,
                 year=year
             ).first()
             
@@ -129,9 +131,10 @@ class FactoidEngine:
     def _get_population(self, council: Council, year: FinancialYear) -> Optional[int]:
         """Get council population for per capita calculations"""
         try:
+            slug = DataField.from_variable_name('population').slug
             pop_characteristic = CouncilCharacteristic.objects.filter(
                 council=council,
-                field__variable_name='population',
+                field__slug=slug,
                 year=year
             ).first()
             
@@ -345,7 +348,7 @@ class FactoidEngine:
             # Create new dependencies
             for field_name in template.referenced_fields:
                 try:
-                    field = DataField.objects.get(variable_name=field_name)
+                    field = DataField.from_variable_name(field_name)
                     FactoidFieldDependency.objects.create(
                         template=template,
                         field=field,

--- a/council_finance/tests/test_factoid_template_validation.py
+++ b/council_finance/tests/test_factoid_template_validation.py
@@ -1,0 +1,15 @@
+from django.test import TestCase
+from council_finance.models import DataField, FactoidTemplate
+
+
+class FactoidTemplateValidationTest(TestCase):
+    def test_validate_template_with_financial_prefix(self):
+        DataField.objects.create(name="Total Debt", slug="total-debt")
+        template = FactoidTemplate.objects.create(
+            name="Debt Template",
+            template_text="Total debt is {financial.total_debt}"
+        )
+
+        self.assertTrue(template.validate_template())
+        self.assertEqual(template.validation_errors, [])
+

--- a/frontend/src/components/FactoidBuilder.jsx
+++ b/frontend/src/components/FactoidBuilder.jsx
@@ -29,6 +29,7 @@ const FactoidBuilder = () => {
     priority: 50,
     is_active: true,
   });
+  const [templateId, setTemplateId] = useState(null);
 
   const [isDirty, setIsDirty] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -73,8 +74,8 @@ const FactoidBuilder = () => {
     
     // Auto-validate on template text changes
     if (field === 'template_text') {
-      validateTemplate(value);
-      generatePreview(value);
+      validateTemplate(value, templateId);
+      generatePreview(value, { templateId });
     }
   }, [validateTemplate, generatePreview]);
 
@@ -118,6 +119,7 @@ const FactoidBuilder = () => {
     try {
       const result = await saveTemplate(template);
       if (result.success) {
+        setTemplateId(result.data.id);
         setIsDirty(false);
         alert('Template saved successfully!');
       } else {


### PR DESCRIPTION
## Summary
- implement variable name helpers on `DataField`
- update factoid template validation and engine to use new helper
- update frontend hook to support unsaved templates and surface API errors
- track template id in the builder component
- add regression test for validating templates with financial prefixes

## Testing
- `pytest council_finance/tests/test_factoid_template_validation.py -q --nomigrations`

------
https://chatgpt.com/codex/tasks/task_e_6884c5a21efc8331ab387b3606ffb0ea